### PR TITLE
Implementing file name exclude patterns

### DIFF
--- a/src/plugins/files/forms/configwidget.ui
+++ b/src/plugins/files/forms/configwidget.ui
@@ -10,119 +10,144 @@
     <height>392</height>
    </rect>
   </property>
-  <layout class="QVBoxLayout" name="verticallayout_2" stretch="1,0,0">
+  <layout class="QVBoxLayout" name="verticallayout_2" stretch="0,0,0">
    <item>
-    <widget class="QGroupBox" name="groupBox_1">
-     <property name="title">
-      <string>Paths</string>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_4">
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <item>
-       <widget class="QListWidget" name="listWidget_paths">
-        <property name="alternatingRowColors">
-         <bool>true</bool>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QGroupBox" name="groupBox_1">
+       <property name="title">
+        <string>Paths</string>
+       </property>
+       <layout class="QHBoxLayout" name="horizontalLayout_4">
+        <property name="leftMargin">
+         <number>0</number>
         </property>
-        <property name="uniformItemSizes">
-         <bool>true</bool>
+        <property name="topMargin">
+         <number>0</number>
         </property>
-        <property name="sortingEnabled">
-         <bool>true</bool>
+        <property name="rightMargin">
+         <number>0</number>
         </property>
-       </widget>
-      </item>
-      <item>
-       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
         <item>
-         <widget class="QPushButton" name="pushButton_add">
-          <property name="text">
-           <string>Add</string>
+         <widget class="QListWidget" name="listWidget_paths">
+          <property name="alternatingRowColors">
+           <bool>true</bool>
+          </property>
+          <property name="uniformItemSizes">
+           <bool>true</bool>
+          </property>
+          <property name="sortingEnabled">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="QPushButton" name="pushButton_remove">
-          <property name="text">
-           <string>Remove</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="pushButton_restore">
-          <property name="text">
-           <string>Restore</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="pushButton_update">
-          <property name="text">
-           <string>Update index</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="verticalSpacer_3">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>40</height>
-           </size>
-          </property>
-         </spacer>
+         <layout class="QVBoxLayout" name="verticalLayout_2">
+          <item>
+           <widget class="QPushButton" name="pushButton_add">
+            <property name="text">
+             <string>Add</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="pushButton_remove">
+            <property name="text">
+             <string>Remove</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="pushButton_restore">
+            <property name="text">
+             <string>Restore</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="pushButton_update">
+            <property name="text">
+             <string>Update index</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="verticalSpacer_3">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
         </item>
        </layout>
-      </item>
-      <item>
-       <widget class="QListWidget" name="listWidget_ignores"/>
-      </item>
-      <item>
-       <layout class="QVBoxLayout" name="verticalLayout_4">
+      </widget>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="groupBox">
+       <property name="title">
+        <string>Ignore Patterns</string>
+       </property>
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
         <item>
-         <widget class="QPushButton" name="pushButton_addIgnore">
-          <property name="text">
-           <string>Add</string>
-          </property>
-         </widget>
+         <widget class="QListWidget" name="listWidget_ignores"/>
         </item>
         <item>
-         <widget class="QPushButton" name="pushButton_removeIgnore">
-          <property name="text">
-           <string>Remove</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="verticalSpacer_5">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>40</height>
-           </size>
-          </property>
-         </spacer>
+         <layout class="QVBoxLayout" name="verticalLayout_4">
+          <item>
+           <widget class="QPushButton" name="pushButton_addIgnore">
+            <property name="text">
+             <string>Add</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="pushButton_removeIgnore">
+            <property name="text">
+             <string>Remove</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="verticalSpacer_5">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
         </item>
        </layout>
-      </item>
-     </layout>
-    </widget>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">

--- a/src/plugins/files/forms/configwidget.ui
+++ b/src/plugins/files/forms/configwidget.ui
@@ -2,6 +2,14 @@
 <ui version="4.0">
  <class>Files::ConfigWidget</class>
  <widget class="QWidget" name="Files::ConfigWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>538</width>
+    <height>392</height>
+   </rect>
+  </property>
   <layout class="QVBoxLayout" name="verticallayout_2" stretch="1,0,0">
    <item>
     <widget class="QGroupBox" name="groupBox_1">
@@ -66,6 +74,40 @@
         </item>
         <item>
          <spacer name="verticalSpacer_3">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="QListWidget" name="listWidget_ignores"/>
+      </item>
+      <item>
+       <layout class="QVBoxLayout" name="verticalLayout_4">
+        <item>
+         <widget class="QPushButton" name="pushButton_addIgnore">
+          <property name="text">
+           <string>Add</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="pushButton_removeIgnore">
+          <property name="text">
+           <string>Remove</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="verticalSpacer_5">
           <property name="orientation">
            <enum>Qt::Vertical</enum>
           </property>

--- a/src/plugins/files/src/configwidget.cpp
+++ b/src/plugins/files/src/configwidget.cpp
@@ -17,7 +17,7 @@
 #include "configwidget.h"
 #include <QFileDialog>
 #include <QStandardPaths>
-#include <QStandardPaths>
+#include <QInputDialog>
 #include "mimetypechooser.h"
 
 /** ***************************************************************************/
@@ -26,6 +26,10 @@ Files::ConfigWidget::ConfigWidget(QWidget *parent) : QWidget(parent) {
     connect(ui.pushButton_add, &QPushButton::clicked, this, &ConfigWidget::onButton_PathAdd);
     connect(ui.pushButton_remove, &QPushButton::clicked, this, &ConfigWidget::onButton_PathRemove);
     connect(ui.pushButton_advanced, &QPushButton::clicked, this, &ConfigWidget::onButton_Advanced);
+
+    connect(ui.pushButton_addIgnore, &QPushButton::clicked, this, &ConfigWidget::onButton_PathAddIgnore);
+    connect(ui.pushButton_removeIgnore, &QPushButton::clicked, this, &ConfigWidget::onButton_PathRemoveIgnore);
+
     // TODO: Implement mime filter
     ui.pushButton_advanced->hide();
 }
@@ -74,4 +78,25 @@ void Files::ConfigWidget::onButton_PathRemove() {
 void Files::ConfigWidget::onButton_Advanced() {
     MimeTypeChooser *c = new MimeTypeChooser;
     c->show();
+}
+
+
+
+/** ***************************************************************************/
+void Files::ConfigWidget::onButton_PathAddIgnore() {
+    QString path = QInputDialog::getText(this, "Add ignore-path", "Enter wildcard-path to ignore:");
+
+    if(path.isEmpty())
+        return;
+
+    emit requestAddIgnorePath(path);
+}
+
+
+
+/** ***************************************************************************/
+void Files::ConfigWidget::onButton_PathRemoveIgnore() {
+    if (ui.listWidget_ignores->currentItem() == nullptr)
+        return;
+    emit requestRemoveIgnorePath(ui.listWidget_ignores->currentItem()->text());
 }

--- a/src/plugins/files/src/configwidget.h
+++ b/src/plugins/files/src/configwidget.h
@@ -38,10 +38,15 @@ private:
     void onButton_RestorePaths();
     void onButton_Advanced();
 
+    void onButton_PathAddIgnore();
+    void onButton_PathRemoveIgnore();
+
 
 signals:
     void requestAddPath(const QString&);
     void requestRemovePath(const QString&);
+    void requestAddIgnorePath(const QString&);
+    void requestRemoveIgnorePath(const QString&);
 
 };
 }

--- a/src/plugins/files/src/indexer.cpp
+++ b/src/plugins/files/src/indexer.cpp
@@ -83,6 +83,12 @@ void Files::Extension::Indexer::run() {
             std::vector<QRegExp> ignores;
             ignores.push_back(QRegExp(extension_->IGNOREFILE, Qt::CaseSensitive, QRegExp::Wildcard));
 
+            // And those which are set in the config widget
+            QStringList& ignoreList = extension_->getIgnoreRegexes();
+            for (QString& str : ignoreList) {
+                ignores.push_back(QRegExp(str, Qt::CaseSensitive, QRegExp::Wildcard));
+            }
+
             // Read the ignore file, see http://doc.qt.io/qt-5/qregexp.html#wildcard-matching
             QFile file(QDir(canonicalPath).filePath(extension_->IGNOREFILE));
             if (file.open(QIODevice::ReadOnly | QIODevice::Text)) {

--- a/src/plugins/files/src/main.cpp
+++ b/src/plugins/files/src/main.cpp
@@ -28,6 +28,7 @@
 #include "query.h"
 
 const char* Files::Extension::CFG_PATHS           = "paths";
+const char* Files::Extension::CFG_IGNORES         = "ignores";
 const char* Files::Extension::CFG_FUZZY           = "fuzzy";
 const bool  Files::Extension::DEF_FUZZY           = false;
 const char* Files::Extension::CFG_INDEX_AUDIO     = "index_audio";
@@ -69,6 +70,11 @@ Files::Extension::Extension()
     rootDirs_ = s.value(CFG_PATHS).toStringList();
     if (rootDirs_.isEmpty())
         restorePaths();
+
+    QVariant v = s.value(CFG_IGNORES);
+    if (v.isValid() && v.canConvert(QMetaType::QStringList))
+        ignores_ = v.toStringList();
+
     s.endGroup();
 
     // Deserialize data
@@ -148,10 +154,15 @@ QWidget *Files::Extension::widget(QWidget *parent) {
 
         // Paths
         widget_->ui.listWidget_paths->addItems(rootDirs_);
+        widget_->ui.listWidget_ignores->addItems(ignores_);
         connect(this, &Extension::rootDirsChanged, widget_->ui.listWidget_paths, &QListWidget::clear);
         connect(this, &Extension::rootDirsChanged, widget_->ui.listWidget_paths, &QListWidget::addItems);
+        connect(this, &Extension::ignoreDirsChanged, widget_->ui.listWidget_ignores, &QListWidget::clear);
+        connect(this, &Extension::ignoreDirsChanged, widget_->ui.listWidget_ignores, &QListWidget::addItems);
         connect(widget_.data(), &ConfigWidget::requestAddPath, this, &Extension::addDir);
         connect(widget_.data(), &ConfigWidget::requestRemovePath, this, &Extension::removeDir);
+        connect(widget_.data(), &ConfigWidget::requestAddIgnorePath, this, &Extension::addIgnoreDir);
+        connect(widget_.data(), &ConfigWidget::requestRemoveIgnorePath, this, &Extension::removeIgnoreDir);
         connect(widget_->ui.pushButton_restore, &QPushButton::clicked, this, &Extension::restorePaths);
         connect(widget_->ui.pushButton_update, &QPushButton::clicked, this, &Extension::updateIndex, Qt::QueuedConnection);
 
@@ -277,6 +288,34 @@ void Files::Extension::removeDir(const QString &dirPath) {
 
     // Update the widget, if it is visible atm
     emit rootDirsChanged(rootDirs_);
+}
+
+
+
+/** ***************************************************************************/
+void Files::Extension::addIgnoreDir(const QString &regex) {
+    ignores_.append(regex);
+
+    QSettings s(qApp->applicationName());
+    s.beginGroup(id);
+    s.setValue(CFG_IGNORES, ignores_);
+    s.endGroup();
+
+    emit ignoreDirsChanged(ignores_);
+}
+
+
+
+/** ***************************************************************************/
+void Files::Extension::removeIgnoreDir(const QString &regex) {
+    ignores_.removeAll(regex);
+
+    QSettings s(qApp->applicationName());
+    s.beginGroup(id);
+    s.setValue(CFG_IGNORES, ignores_);
+    s.endGroup();
+
+    emit ignoreDirsChanged(ignores_);
 }
 
 

--- a/src/plugins/files/src/main.cpp
+++ b/src/plugins/files/src/main.cpp
@@ -297,7 +297,7 @@ void Files::Extension::addIgnoreDir(const QString &regex) {
     ignores_.append(regex);
 
     QSettings s(qApp->applicationName());
-    s.beginGroup(id);
+    s.beginGroup(Core::Extension::id);
     s.setValue(CFG_IGNORES, ignores_);
     s.endGroup();
 
@@ -311,7 +311,7 @@ void Files::Extension::removeIgnoreDir(const QString &regex) {
     ignores_.removeAll(regex);
 
     QSettings s(qApp->applicationName());
-    s.beginGroup(id);
+    s.beginGroup(Core::Extension::id);
     s.setValue(CFG_IGNORES, ignores_);
     s.endGroup();
 

--- a/src/plugins/files/src/main.h
+++ b/src/plugins/files/src/main.h
@@ -62,6 +62,8 @@ public:
 
     void addDir(const QString &dirPath);
     void removeDir(const QString &dirPath);
+    void addIgnoreDir(const QString &regex);
+    void removeIgnoreDir(const QString &regex);
     void restorePaths();
     void updateIndex();
 
@@ -93,6 +95,8 @@ public:
     bool fuzzy();
     void setFuzzy(bool b = true);
 
+    QStringList& getIgnoreRegexes() { return ignores_; }
+
 private:
     QPointer<ConfigWidget> widget_;
     vector<shared_ptr<File>> index_;
@@ -100,6 +104,7 @@ private:
     QMutex indexAccess_;
     QPointer<Indexer> indexer_;
     QTimer indexIntervalTimer_;
+    QStringList ignores_;
 
     // Index Properties
     QStringList rootDirs_;
@@ -113,6 +118,7 @@ private:
 
     /* const */
     static const char* CFG_PATHS;
+    static const char* CFG_IGNORES;
     static const char* CFG_FUZZY;
     static const bool  DEF_FUZZY;
     static const char* CFG_INDEX_AUDIO;
@@ -135,6 +141,7 @@ private:
 
 signals:
     void rootDirsChanged(const QStringList&);
+    void ignoreDirsChanged(const QStringList&);
     void statusInfo(const QString&);
 
 private slots:


### PR DESCRIPTION
Implementing the feature requested with #115
This preloads the .albertignore file in every directory with values.
This also creates a "virtual file" in every directory, meaning even if no .albertignore file is present it will appear as if the file is present and its content is according to what's configured in the config-widget of the files-ext.
This also means that there is no filtering for file paths. Only directory items. 
I may implement this at some point too, if the need arises
