### PR TITLE
Fixed name of VirtualBox

### DIFF
--- a/src/plugins/virtualbox/metadata.json
+++ b/src/plugins/virtualbox/metadata.json
@@ -1,10 +1,10 @@
 {
     "id" :              "org.albert.extension.virtualbox",
-    "name" :            "Virtual Box",
+    "name" :            "VirtualBox",
     "version" :         "1.0",
     "platform" :        "Linux",
     "group" :           "Extensions",
     "author" :          "Manuel Schneider",
     "dependencies" :    ["virtualbox"],
-    "enabledbydefault":    false
+    "enabledbydefault": false
 }

--- a/src/plugins/virtualbox/src/main.cpp
+++ b/src/plugins/virtualbox/src/main.cpp
@@ -42,7 +42,7 @@ public:
     QPointer<ConfigWidget> widget;
     QList<VM*> vms;
     QFileSystemWatcher vboxWatcher;
-    const char* name_ = "Virtual Box";
+    const char* name_ = "VirtualBox";
 
     void rescanVBoxConfig(QString path);
 };

--- a/src/plugins/virtualbox/src/main.h
+++ b/src/plugins/virtualbox/src/main.h
@@ -43,7 +43,7 @@ public:
      * Implementation of extension interface
      */
 
-    QString name() const override { return tr("Virtual Box"); }
+    QString name() const override { return tr("VirtualBox"); }
     QWidget *widget(QWidget *parent = nullptr) override;
     void setupSession() override;
     void handleQuery(Core::Query *) override;


### PR DESCRIPTION
Renamed references of "Virtual Box" to "VirtualBox" as per the name of the software.