### PR TITLE
Change the way the `proposal` and `action` list selected items are rendered

### DIFF
--- a/data/ArcTemplate.qss
+++ b/data/ArcTemplate.qss
@@ -7,9 +7,12 @@
  */
 
 * {
-  border: none;
+  	border: none;
 	color : #%foreground_color%;
 	background-color: #%background_color%;
+	selection-background-color: #%foreground_color%;
+	selection-color: #%foreground_color%;
+	alternate-background-color: #%foreground_color%;
 }
 
 #frame {
@@ -17,7 +20,7 @@
 	border-radius: 3px;
 	background-color: #%background_color%;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:640px;
 	max-width:640px;
 }
@@ -35,14 +38,14 @@
 #settingsButton {
 	color : #%button_color%;
 	background-color: #%background_color%;
-  padding: 4px;
+	padding: 4px;
 
-  /* Respect the frame border */
-  margin: 6px 6px 0px 0px;
-  border-top-right-radius: 6px;
-  border-bottom-left-radius: 10px;
+	/* Respect the frame border */
+	margin: 6px 6px 0px 0px;
+	border-top-right-radius: 6px;
+	border-bottom-left-radius: 10px;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:13px;
 	min-height:13px;
 	max-width:13px;
@@ -89,7 +92,7 @@ QListView#actionList::item{
 
 QListView#proposalList {
 	icon-size: 44px;
-	font-size: 26px;
+	font-size: 26px;	
 }
 
 QListView#proposalList::item{

--- a/data/SlickTemplate.qss
+++ b/data/SlickTemplate.qss
@@ -7,11 +7,14 @@
  */
 
 * {
-  border: none;
-  font-family:"DejaVu Sans";
-  font-weight: 200;
+	border: none;
+	font-family:"DejaVu Sans";
+	font-weight: 200;
 	color : #%foreground_color%;
 	background-color: #%background_color%;
+	selection-background-color: #%foreground_color%;
+	selection-color: #%foreground_color%;
+	alternate-background-color: #%foreground_color%;
 }
 
 #frame {
@@ -20,7 +23,7 @@
 	background-color: #%background_color%;
 	border: 1px solid #20808080;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:640px;
 	max-width:640px;
 }
@@ -35,9 +38,9 @@
 #settingsButton {
 	color: #%button_color%;
 	background-color: transparent;
-  padding: 8px;
+	padding: 8px;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:14px;
 	min-height:14px;
 	max-width:14px;

--- a/data/StandardThemeTemplate.qss
+++ b/data/StandardThemeTemplate.qss
@@ -7,9 +7,12 @@
  */
 
 * {
-  border: none;
+	border: none;
 	color : #%foreground_color%;
 	background-color: #%background_color%;
+	selection-background-color: #%foreground_color%;
+	selection-color: #%foreground_color%;
+	alternate-background-color: #%foreground_color%;
 }
 
 #frame {
@@ -18,7 +21,7 @@
 	background-color: #%background_color%;
 	border: 6px solid #%border_color%;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:640px;
 	max-width:640px;
 }
@@ -35,14 +38,14 @@
 #settingsButton {
 	color : #%button_color%;
 	background-color: #%background_color%;
-  padding: 4px;
+	padding: 4px;
 
-  /* Respect the frame border */
-  margin: 6px 6px 0px 0px;
-  border-top-right-radius: 6px;
-  border-bottom-left-radius: 10px;
+	/* Respect the frame border */
+	margin: 6px 6px 0px 0px;
+	border-top-right-radius: 6px;
+	border-bottom-left-radius: 10px;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:13px;
 	min-height:13px;
 	max-width:13px;

--- a/data/themes/Arc Blue.qss
+++ b/data/themes/Arc Blue.qss
@@ -7,9 +7,12 @@
  */
 
 * {
-  border: none;
+  	border: none;
 	color : #727A8F;
 	background-color: #e7e8eb;
+	selection-background-color: #727A8F;
+	selection-color: #727A8F;
+    alternate-background-color: #727A8F;
 }
 
 #frame {
@@ -17,7 +20,7 @@
 	border-radius: 3px;
 	background-color: #e7e8eb;
 
-  /* Workaround for Qt to get fixed size button*/
+  	/* Workaround for Qt to get fixed size button*/
 	min-width:640px;
 	max-width:640px;
 }
@@ -35,14 +38,14 @@
 #settingsButton {
 	color : #ffffff;
 	background-color: #e7e8eb;
-  padding: 4px;
+	padding: 4px;
 
-  /* Respect the frame border */
-  margin: 6px 6px 0px 0px;
-  border-top-right-radius: 6px;
-  border-bottom-left-radius: 10px;
+	/* Respect the frame border */
+	margin: 6px 6px 0px 0px;
+	border-top-right-radius: 6px;
+	border-bottom-left-radius: 10px;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:13px;
 	min-height:13px;
 	max-width:13px;
@@ -89,7 +92,7 @@ QListView#actionList::item{
 
 QListView#proposalList {
 	icon-size: 44px;
-	font-size: 26px;
+	font-size: 26px;	
 }
 
 QListView#proposalList::item{

--- a/data/themes/Arc Dark Blue.qss
+++ b/data/themes/Arc Dark Blue.qss
@@ -10,6 +10,9 @@
   border: none;
 	color : #AFB8C5;
 	background-color: #383C4A;
+	selection-background-color: #AFB8C5;
+	selection-color: #AFB8C5;
+	alternate-background-color: #AFB8C5;
 }
 
 #frame {
@@ -17,7 +20,7 @@
 	border-radius: 3px;
 	background-color: #383C4A;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:640px;
 	max-width:640px;
 }
@@ -35,14 +38,14 @@
 #settingsButton {
 	color : #ffffff;
 	background-color: #383C4A;
-  padding: 4px;
+	padding: 4px;
 
-  /* Respect the frame border */
-  margin: 6px 6px 0px 0px;
-  border-top-right-radius: 6px;
-  border-bottom-left-radius: 10px;
+	/* Respect the frame border */
+	margin: 6px 6px 0px 0px;
+	border-top-right-radius: 6px;
+	border-bottom-left-radius: 10px;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:13px;
 	min-height:13px;
 	max-width:13px;

--- a/data/themes/Arc Dark Grey.qss
+++ b/data/themes/Arc Dark Grey.qss
@@ -7,9 +7,12 @@
  */
 
 * {
-  border: none;
+  	border: none;
 	color : #AFB8C5;
-	background-color: #383C4A;
+	background-color: #383C4A;	
+	selection-background-color: #AFB8C5;
+	selection-color: #AFB8C5;
+	alternate-background-color: #AFB8C5;
 }
 
 #frame {
@@ -17,7 +20,7 @@
 	border-radius: 3px;
 	background-color: #383C4A;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:640px;
 	max-width:640px;
 }
@@ -35,14 +38,14 @@
 #settingsButton {
 	color : #ffffff;
 	background-color: #383C4A;
-  padding: 4px;
+	padding: 4px;
 
-  /* Respect the frame border */
-  margin: 6px 6px 0px 0px;
-  border-top-right-radius: 6px;
-  border-bottom-left-radius: 10px;
+	/* Respect the frame border */
+	margin: 6px 6px 0px 0px;
+	border-top-right-radius: 6px;
+	border-bottom-left-radius: 10px;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:13px;
 	min-height:13px;
 	max-width:13px;

--- a/data/themes/Arc Grey.qss
+++ b/data/themes/Arc Grey.qss
@@ -7,9 +7,12 @@
  */
 
 * {
-  border: none;
+  	border: none;
 	color : #727A8F;
-	background-color: #e7e8eb;
+	background-color: #e7e8eb;	
+	selection-background-color: #727A8F;
+	selection-color: #727A8F;
+	alternate-background-color: #727A8F;
 }
 
 #frame {
@@ -17,7 +20,7 @@
 	border-radius: 3px;
 	background-color: #e7e8eb;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:640px;
 	max-width:640px;
 }
@@ -35,14 +38,14 @@
 #settingsButton {
 	color : #ffffff;
 	background-color: #e7e8eb;
-  padding: 4px;
+	padding: 4px;
 
-  /* Respect the frame border */
-  margin: 6px 6px 0px 0px;
-  border-top-right-radius: 6px;
-  border-bottom-left-radius: 10px;
+	/* Respect the frame border */
+	margin: 6px 6px 0px 0px;
+	border-top-right-radius: 6px;
+	border-bottom-left-radius: 10px;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:13px;
 	min-height:13px;
 	max-width:13px;

--- a/data/themes/Bright.qss
+++ b/data/themes/Bright.qss
@@ -9,7 +9,10 @@
 * {
   border: none;
 	color : #808080;
-	background-color: #FFFFFF;
+	background-color: #FFFFFF;	
+	selection-background-color: #808080;
+	selection-color: #808080;
+	alternate-background-color: #808080;
 }
 
 #frame {
@@ -18,7 +21,7 @@
 	background-color: #FFFFFF;
 	border: 6px solid #808080;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:640px;
 	max-width:640px;
 }
@@ -35,14 +38,14 @@
 #settingsButton {
 	color : #808080;
 	background-color: #FFFFFF;
-  padding: 4px;
+	padding: 4px;
 
-  /* Respect the frame border */
-  margin: 6px 6px 0px 0px;
-  border-top-right-radius: 6px;
-  border-bottom-left-radius: 10px;
+	/* Respect the frame border */
+	margin: 6px 6px 0px 0px;
+	border-top-right-radius: 6px;
+	border-bottom-left-radius: 10px;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:13px;
 	min-height:13px;
 	max-width:13px;

--- a/data/themes/BrightBlue.qss
+++ b/data/themes/BrightBlue.qss
@@ -7,9 +7,12 @@
  */
 
 * {
-  border: none;
+	border: none;
 	color : #808080;
 	background-color: #FFFFFF;
+	selection-background-color: #808080;
+	selection-color: #808080;
+	alternate-background-color: #808080;
 }
 
 #frame {
@@ -18,7 +21,7 @@
 	background-color: #FFFFFF;
 	border: 6px solid #0080FF;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:640px;
 	max-width:640px;
 }
@@ -35,14 +38,14 @@
 #settingsButton {
 	color : #0080FF;
 	background-color: #FFFFFF;
-  padding: 4px;
+	padding: 4px;
 
-  /* Respect the frame border */
-  margin: 6px 6px 0px 0px;
-  border-top-right-radius: 6px;
-  border-bottom-left-radius: 10px;
+	/* Respect the frame border */
+	margin: 6px 6px 0px 0px;
+	border-top-right-radius: 6px;
+	border-bottom-left-radius: 10px;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:13px;
 	min-height:13px;
 	max-width:13px;

--- a/data/themes/BrightGreen.qss
+++ b/data/themes/BrightGreen.qss
@@ -7,9 +7,12 @@
  */
 
 * {
-  border: none;
+	border: none;
 	color : #808080;
 	background-color: #FFFFFF;
+	selection-background-color: #808080;
+	selection-color: #808080;
+	alternate-background-color: #808080;
 }
 
 #frame {
@@ -18,7 +21,7 @@
 	background-color: #FFFFFF;
 	border: 6px solid #80FF00;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:640px;
 	max-width:640px;
 }
@@ -35,14 +38,14 @@
 #settingsButton {
 	color : #80FF00;
 	background-color: #FFFFFF;
-  padding: 4px;
+	padding: 4px;
 
-  /* Respect the frame border */
-  margin: 6px 6px 0px 0px;
-  border-top-right-radius: 6px;
-  border-bottom-left-radius: 10px;
+	/* Respect the frame border */
+	margin: 6px 6px 0px 0px;
+	border-top-right-radius: 6px;
+	border-bottom-left-radius: 10px;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:13px;
 	min-height:13px;
 	max-width:13px;

--- a/data/themes/BrightMagenta.qss
+++ b/data/themes/BrightMagenta.qss
@@ -7,9 +7,12 @@
  */
 
 * {
-  border: none;
+	border: none;
 	color : #808080;
 	background-color: #FFFFFF;
+	selection-background-color: #808080;
+	selection-color: #808080;
+	alternate-background-color: #808080;
 }
 
 #frame {
@@ -18,7 +21,7 @@
 	background-color: #FFFFFF;
 	border: 6px solid #FF0080;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:640px;
 	max-width:640px;
 }
@@ -35,14 +38,14 @@
 #settingsButton {
 	color : #FF0080;
 	background-color: #FFFFFF;
-  padding: 4px;
+	padding: 4px;
 
-  /* Respect the frame border */
-  margin: 6px 6px 0px 0px;
-  border-top-right-radius: 6px;
-  border-bottom-left-radius: 10px;
+	/* Respect the frame border */
+	margin: 6px 6px 0px 0px;
+	border-top-right-radius: 6px;
+	border-bottom-left-radius: 10px;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:13px;
 	min-height:13px;
 	max-width:13px;

--- a/data/themes/BrightMint.qss
+++ b/data/themes/BrightMint.qss
@@ -7,9 +7,12 @@
  */
 
 * {
-  border: none;
+	border: none;
 	color : #808080;
 	background-color: #FFFFFF;
+	selection-background-color: #808080;
+	selection-color: #808080;
+	alternate-background-color: #808080;
 }
 
 #frame {
@@ -18,7 +21,7 @@
 	background-color: #FFFFFF;
 	border: 6px solid #00FF80;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:640px;
 	max-width:640px;
 }
@@ -35,14 +38,14 @@
 #settingsButton {
 	color : #00FF80;
 	background-color: #FFFFFF;
-  padding: 4px;
+	padding: 4px;
 
-  /* Respect the frame border */
-  margin: 6px 6px 0px 0px;
-  border-top-right-radius: 6px;
-  border-bottom-left-radius: 10px;
+	/* Respect the frame border */
+	margin: 6px 6px 0px 0px;
+	border-top-right-radius: 6px;
+	border-bottom-left-radius: 10px;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:13px;
 	min-height:13px;
 	max-width:13px;

--- a/data/themes/BrightOrange.qss
+++ b/data/themes/BrightOrange.qss
@@ -7,9 +7,12 @@
  */
 
 * {
-  border: none;
+	border: none;
 	color : #808080;
 	background-color: #FFFFFF;
+	selection-background-color: #808080;
+	selection-color: #808080;
+	alternate-background-color: #808080;
 }
 
 #frame {
@@ -18,7 +21,7 @@
 	background-color: #FFFFFF;
 	border: 6px solid #FF8000;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:640px;
 	max-width:640px;
 }
@@ -35,14 +38,14 @@
 #settingsButton {
 	color : #FF8000;
 	background-color: #FFFFFF;
-  padding: 4px;
+	padding: 4px;
 
-  /* Respect the frame border */
-  margin: 6px 6px 0px 0px;
-  border-top-right-radius: 6px;
-  border-bottom-left-radius: 10px;
+	/* Respect the frame border */
+	margin: 6px 6px 0px 0px;
+	border-top-right-radius: 6px;
+	border-bottom-left-radius: 10px;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:13px;
 	min-height:13px;
 	max-width:13px;

--- a/data/themes/BrightViolet.qss
+++ b/data/themes/BrightViolet.qss
@@ -7,9 +7,12 @@
  */
 
 * {
-  border: none;
+	border: none;
 	color : #808080;
 	background-color: #FFFFFF;
+	selection-background-color: #808080;
+	selection-color: #808080;
+	alternate-background-color: #808080;
 }
 
 #frame {
@@ -18,7 +21,7 @@
 	background-color: #FFFFFF;
 	border: 6px solid #8000FF;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:640px;
 	max-width:640px;
 }
@@ -35,14 +38,14 @@
 #settingsButton {
 	color : #8000FF;
 	background-color: #FFFFFF;
-  padding: 4px;
+	padding: 4px;
 
-  /* Respect the frame border */
-  margin: 6px 6px 0px 0px;
-  border-top-right-radius: 6px;
-  border-bottom-left-radius: 10px;
+	/* Respect the frame border */
+	margin: 6px 6px 0px 0px;
+	border-top-right-radius: 6px;
+	border-bottom-left-radius: 10px;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:13px;
 	min-height:13px;
 	max-width:13px;

--- a/data/themes/Dark.qss
+++ b/data/themes/Dark.qss
@@ -7,9 +7,12 @@
  */
 
 * {
-  border: none;
+	border: none;
 	color : #808080;
 	background-color: #404040;
+	selection-background-color: #808080;
+	selection-color: #808080;
+	alternate-background-color: #808080;
 }
 
 #frame {
@@ -18,7 +21,7 @@
 	background-color: #404040;
 	border: 6px solid #808080;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:640px;
 	max-width:640px;
 }
@@ -35,14 +38,14 @@
 #settingsButton {
 	color : #808080;
 	background-color: #404040;
-  padding: 4px;
+	padding: 4px;
 
-  /* Respect the frame border */
-  margin: 6px 6px 0px 0px;
-  border-top-right-radius: 6px;
-  border-bottom-left-radius: 10px;
+	/* Respect the frame border */
+	margin: 6px 6px 0px 0px;
+	border-top-right-radius: 6px;
+	border-bottom-left-radius: 10px;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:13px;
 	min-height:13px;
 	max-width:13px;

--- a/data/themes/DarkBlue.qss
+++ b/data/themes/DarkBlue.qss
@@ -7,9 +7,12 @@
  */
 
 * {
-  border: none;
+	border: none;
 	color : #808080;
 	background-color: #404040;
+	selection-background-color: #808080;
+	selection-color: #808080;
+	alternate-background-color: #808080;
 }
 
 #frame {
@@ -18,7 +21,7 @@
 	background-color: #404040;
 	border: 6px solid #0080FF;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:640px;
 	max-width:640px;
 }
@@ -35,14 +38,14 @@
 #settingsButton {
 	color : #0080FF;
 	background-color: #404040;
-  padding: 4px;
+	padding: 4px;
 
-  /* Respect the frame border */
-  margin: 6px 6px 0px 0px;
-  border-top-right-radius: 6px;
-  border-bottom-left-radius: 10px;
+	/* Respect the frame border */
+	margin: 6px 6px 0px 0px;
+	border-top-right-radius: 6px;
+	border-bottom-left-radius: 10px;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:13px;
 	min-height:13px;
 	max-width:13px;

--- a/data/themes/DarkGreen.qss
+++ b/data/themes/DarkGreen.qss
@@ -7,9 +7,12 @@
  */
 
 * {
-  border: none;
+	border: none;
 	color : #808080;
 	background-color: #404040;
+	selection-background-color: #808080;
+	selection-color: #808080;
+	alternate-background-color: #808080;
 }
 
 #frame {
@@ -18,7 +21,7 @@
 	background-color: #404040;
 	border: 6px solid #80FF00;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:640px;
 	max-width:640px;
 }
@@ -35,14 +38,14 @@
 #settingsButton {
 	color : #80FF00;
 	background-color: #404040;
-  padding: 4px;
+	padding: 4px;
 
-  /* Respect the frame border */
-  margin: 6px 6px 0px 0px;
-  border-top-right-radius: 6px;
-  border-bottom-left-radius: 10px;
+	/* Respect the frame border */
+	margin: 6px 6px 0px 0px;
+	border-top-right-radius: 6px;
+	border-bottom-left-radius: 10px;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:13px;
 	min-height:13px;
 	max-width:13px;

--- a/data/themes/DarkMagenta.qss
+++ b/data/themes/DarkMagenta.qss
@@ -7,9 +7,12 @@
  */
 
 * {
-  border: none;
+	border: none;
 	color : #808080;
 	background-color: #404040;
+	selection-background-color: #808080;
+	selection-color: #808080;
+	alternate-background-color: #808080;
 }
 
 #frame {
@@ -18,7 +21,7 @@
 	background-color: #404040;
 	border: 6px solid #FF0080;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:640px;
 	max-width:640px;
 }
@@ -35,14 +38,14 @@
 #settingsButton {
 	color : #FF0080;
 	background-color: #404040;
-  padding: 4px;
+	padding: 4px;
 
-  /* Respect the frame border */
-  margin: 6px 6px 0px 0px;
-  border-top-right-radius: 6px;
-  border-bottom-left-radius: 10px;
+	/* Respect the frame border */
+	margin: 6px 6px 0px 0px;
+	border-top-right-radius: 6px;
+	border-bottom-left-radius: 10px;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:13px;
 	min-height:13px;
 	max-width:13px;

--- a/data/themes/DarkMint.qss
+++ b/data/themes/DarkMint.qss
@@ -7,9 +7,12 @@
  */
 
 * {
-  border: none;
+	border: none;
 	color : #808080;
 	background-color: #404040;
+	selection-background-color: #808080;
+	selection-color: #808080;
+	alternate-background-color: #808080;
 }
 
 #frame {
@@ -18,7 +21,7 @@
 	background-color: #404040;
 	border: 6px solid #00FF80;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:640px;
 	max-width:640px;
 }
@@ -35,14 +38,14 @@
 #settingsButton {
 	color : #00FF80;
 	background-color: #404040;
-  padding: 4px;
+	padding: 4px;
 
-  /* Respect the frame border */
-  margin: 6px 6px 0px 0px;
-  border-top-right-radius: 6px;
-  border-bottom-left-radius: 10px;
+	/* Respect the frame border */
+	margin: 6px 6px 0px 0px;
+	border-top-right-radius: 6px;
+	border-bottom-left-radius: 10px;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:13px;
 	min-height:13px;
 	max-width:13px;

--- a/data/themes/DarkOrange.qss
+++ b/data/themes/DarkOrange.qss
@@ -7,9 +7,12 @@
  */
 
 * {
-  border: none;
+	border: none;
 	color : #808080;
 	background-color: #404040;
+	selection-background-color: #808080;
+	selection-color: #808080;
+	alternate-background-color: #808080;
 }
 
 #frame {
@@ -18,7 +21,7 @@
 	background-color: #404040;
 	border: 6px solid #FF8000;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:640px;
 	max-width:640px;
 }
@@ -35,14 +38,14 @@
 #settingsButton {
 	color : #FF8000;
 	background-color: #404040;
-  padding: 4px;
+	padding: 4px;
 
-  /* Respect the frame border */
-  margin: 6px 6px 0px 0px;
-  border-top-right-radius: 6px;
-  border-bottom-left-radius: 10px;
+	/* Respect the frame border */
+	margin: 6px 6px 0px 0px;
+	border-top-right-radius: 6px;
+	border-bottom-left-radius: 10px;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:13px;
 	min-height:13px;
 	max-width:13px;

--- a/data/themes/DarkViolet.qss
+++ b/data/themes/DarkViolet.qss
@@ -7,9 +7,12 @@
  */
 
 * {
-  border: none;
+	border: none;
 	color : #808080;
 	background-color: #404040;
+	selection-background-color: #808080;
+	selection-color: #808080;
+	alternate-background-color: #808080;
 }
 
 #frame {
@@ -18,7 +21,7 @@
 	background-color: #404040;
 	border: 6px solid #8000FF;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:640px;
 	max-width:640px;
 }
@@ -35,14 +38,14 @@
 #settingsButton {
 	color : #8000FF;
 	background-color: #404040;
-  padding: 4px;
+	padding: 4px;
 
-  /* Respect the frame border */
-  margin: 6px 6px 0px 0px;
-  border-top-right-radius: 6px;
-  border-bottom-left-radius: 10px;
+	/* Respect the frame border */
+	margin: 6px 6px 0px 0px;
+	border-top-right-radius: 6px;
+	border-bottom-left-radius: 10px;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:13px;
 	min-height:13px;
 	max-width:13px;

--- a/data/themes/Numix Rounded.qss
+++ b/data/themes/Numix Rounded.qss
@@ -10,6 +10,9 @@
 * {
   color : #ccc;
   background-color: #2d2d2d;
+  selection-background-color: #ccc;
+  selection-color: #ccc;
+  alternate-background-color: #ccc;
 }
 
 #frame {

--- a/data/themes/Numix.qss
+++ b/data/themes/Numix.qss
@@ -10,6 +10,9 @@
 * {
   color : #ccc;
   background-color: #2d2d2d;
+  selection-background-color: #ccc;
+  selection-color: #ccc;
+  alternate-background-color: #ccc;
 }
 
 #frame {

--- a/data/themes/SolarizedBrightBlue.qss
+++ b/data/themes/SolarizedBrightBlue.qss
@@ -7,9 +7,12 @@
  */
 
 * {
-  border: none;
+	border: none;
 	color : #586e75;
 	background-color: #fdf6e3;
+	selection-background-color: #586e75;
+  	selection-color: #586e75;
+  	alternate-background-color: #586e75;
 }
 
 #frame {
@@ -18,7 +21,7 @@
 	background-color: #fdf6e3;
 	border: 6px solid #268bd2;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:640px;
 	max-width:640px;
 }
@@ -35,14 +38,14 @@
 #settingsButton {
 	color : #268bd2;
 	background-color: #fdf6e3;
-  padding: 4px;
+	padding: 4px;
 
-  /* Respect the frame border */
-  margin: 6px 6px 0px 0px;
-  border-top-right-radius: 6px;
-  border-bottom-left-radius: 10px;
+	/* Respect the frame border */
+	margin: 6px 6px 0px 0px;
+	border-top-right-radius: 6px;
+	border-bottom-left-radius: 10px;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:13px;
 	min-height:13px;
 	max-width:13px;

--- a/data/themes/SolarizedBrightCyan.qss
+++ b/data/themes/SolarizedBrightCyan.qss
@@ -7,9 +7,12 @@
  */
 
 * {
-  border: none;
+	border: none;
 	color : #586e75;
 	background-color: #fdf6e3;
+	selection-background-color: #586e75;
+  	selection-color: #586e75;
+  	alternate-background-color: #586e75;
 }
 
 #frame {
@@ -18,7 +21,7 @@
 	background-color: #fdf6e3;
 	border: 6px solid #2aa198;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:640px;
 	max-width:640px;
 }
@@ -35,14 +38,14 @@
 #settingsButton {
 	color : #2aa198;
 	background-color: #fdf6e3;
-  padding: 4px;
+	padding: 4px;
 
-  /* Respect the frame border */
-  margin: 6px 6px 0px 0px;
-  border-top-right-radius: 6px;
-  border-bottom-left-radius: 10px;
+	/* Respect the frame border */
+	margin: 6px 6px 0px 0px;
+	border-top-right-radius: 6px;
+	border-bottom-left-radius: 10px;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:13px;
 	min-height:13px;
 	max-width:13px;

--- a/data/themes/SolarizedBrightGreen.qss
+++ b/data/themes/SolarizedBrightGreen.qss
@@ -7,9 +7,12 @@
  */
 
 * {
-  border: none;
+	border: none;
 	color : #586e75;
 	background-color: #fdf6e3;
+	selection-background-color: #586e75;
+  	selection-color: #586e75;
+  	alternate-background-color: #586e75;
 }
 
 #frame {
@@ -18,7 +21,7 @@
 	background-color: #fdf6e3;
 	border: 6px solid #859900;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:640px;
 	max-width:640px;
 }
@@ -35,14 +38,14 @@
 #settingsButton {
 	color : #859900;
 	background-color: #fdf6e3;
-  padding: 4px;
+	padding: 4px;
 
-  /* Respect the frame border */
-  margin: 6px 6px 0px 0px;
-  border-top-right-radius: 6px;
-  border-bottom-left-radius: 10px;
+	/* Respect the frame border */
+	margin: 6px 6px 0px 0px;
+	border-top-right-radius: 6px;
+	border-bottom-left-radius: 10px;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:13px;
 	min-height:13px;
 	max-width:13px;

--- a/data/themes/SolarizedBrightMagenta.qss
+++ b/data/themes/SolarizedBrightMagenta.qss
@@ -10,6 +10,9 @@
   border: none;
 	color : #586e75;
 	background-color: #fdf6e3;
+	selection-background-color: #586e75;
+  	selection-color: #586e75;
+  	alternate-background-color: #586e75;
 }
 
 #frame {
@@ -18,7 +21,7 @@
 	background-color: #fdf6e3;
 	border: 6px solid #d33682;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:640px;
 	max-width:640px;
 }
@@ -35,14 +38,14 @@
 #settingsButton {
 	color : #d33682;
 	background-color: #fdf6e3;
-  padding: 4px;
+	padding: 4px;
 
-  /* Respect the frame border */
-  margin: 6px 6px 0px 0px;
-  border-top-right-radius: 6px;
-  border-bottom-left-radius: 10px;
+	/* Respect the frame border */
+	margin: 6px 6px 0px 0px;
+	border-top-right-radius: 6px;
+	border-bottom-left-radius: 10px;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:13px;
 	min-height:13px;
 	max-width:13px;

--- a/data/themes/SolarizedBrightOrange.qss
+++ b/data/themes/SolarizedBrightOrange.qss
@@ -7,9 +7,12 @@
  */
 
 * {
-  border: none;
+	border: none;
 	color : #586e75;
 	background-color: #fdf6e3;
+	selection-background-color: #586e75;
+  	selection-color: #586e75;
+  	alternate-background-color: #586e75;
 }
 
 #frame {
@@ -18,7 +21,7 @@
 	background-color: #fdf6e3;
 	border: 6px solid #cb4b16;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:640px;
 	max-width:640px;
 }
@@ -35,14 +38,14 @@
 #settingsButton {
 	color : #cb4b16;
 	background-color: #fdf6e3;
-  padding: 4px;
+	padding: 4px;
 
-  /* Respect the frame border */
-  margin: 6px 6px 0px 0px;
-  border-top-right-radius: 6px;
-  border-bottom-left-radius: 10px;
+	/* Respect the frame border */
+	margin: 6px 6px 0px 0px;
+	border-top-right-radius: 6px;
+	border-bottom-left-radius: 10px;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:13px;
 	min-height:13px;
 	max-width:13px;

--- a/data/themes/SolarizedBrightRed.qss
+++ b/data/themes/SolarizedBrightRed.qss
@@ -7,9 +7,12 @@
  */
 
 * {
-  border: none;
+	border: none;
 	color : #586e75;
 	background-color: #fdf6e3;
+	selection-background-color: #586e75;
+  	selection-color: #586e75;
+  	alternate-background-color: #586e75;
 }
 
 #frame {
@@ -18,7 +21,7 @@
 	background-color: #fdf6e3;
 	border: 6px solid #dc322f;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:640px;
 	max-width:640px;
 }
@@ -35,14 +38,14 @@
 #settingsButton {
 	color : #dc322f;
 	background-color: #fdf6e3;
-  padding: 4px;
+	padding: 4px;
 
-  /* Respect the frame border */
-  margin: 6px 6px 0px 0px;
-  border-top-right-radius: 6px;
-  border-bottom-left-radius: 10px;
+	/* Respect the frame border */
+	margin: 6px 6px 0px 0px;
+	border-top-right-radius: 6px;
+	border-bottom-left-radius: 10px;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:13px;
 	min-height:13px;
 	max-width:13px;

--- a/data/themes/SolarizedBrightViolet.qss
+++ b/data/themes/SolarizedBrightViolet.qss
@@ -7,9 +7,12 @@
  */
 
 * {
-  border: none;
+	border: none;
 	color : #586e75;
 	background-color: #fdf6e3;
+	selection-background-color: #586e75;
+  	selection-color: #586e75;
+  	alternate-background-color: #586e75;
 }
 
 #frame {
@@ -18,7 +21,7 @@
 	background-color: #fdf6e3;
 	border: 6px solid #6c71c4;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:640px;
 	max-width:640px;
 }
@@ -35,14 +38,14 @@
 #settingsButton {
 	color : #6c71c4;
 	background-color: #fdf6e3;
-  padding: 4px;
+	padding: 4px;
 
-  /* Respect the frame border */
-  margin: 6px 6px 0px 0px;
-  border-top-right-radius: 6px;
-  border-bottom-left-radius: 10px;
+	/* Respect the frame border */
+	margin: 6px 6px 0px 0px;
+	border-top-right-radius: 6px;
+	border-bottom-left-radius: 10px;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:13px;
 	min-height:13px;
 	max-width:13px;

--- a/data/themes/SolarizedBrightYellow.qss
+++ b/data/themes/SolarizedBrightYellow.qss
@@ -7,9 +7,12 @@
  */
 
 * {
-  border: none;
+	border: none;
 	color : #586e75;
 	background-color: #fdf6e3;
+	selection-background-color: #586e75;
+  	selection-color: #586e75;
+  	alternate-background-color: #586e75;
 }
 
 #frame {
@@ -18,7 +21,7 @@
 	background-color: #fdf6e3;
 	border: 6px solid #b58900;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:640px;
 	max-width:640px;
 }
@@ -35,14 +38,14 @@
 #settingsButton {
 	color : #b58900;
 	background-color: #fdf6e3;
-  padding: 4px;
+	padding: 4px;
 
-  /* Respect the frame border */
-  margin: 6px 6px 0px 0px;
-  border-top-right-radius: 6px;
-  border-bottom-left-radius: 10px;
+	/* Respect the frame border */
+	margin: 6px 6px 0px 0px;
+	border-top-right-radius: 6px;
+	border-bottom-left-radius: 10px;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:13px;
 	min-height:13px;
 	max-width:13px;

--- a/data/themes/SolarizedDarkBlue.qss
+++ b/data/themes/SolarizedDarkBlue.qss
@@ -7,9 +7,12 @@
  */
 
 * {
-  border: none;
+  	border: none;
 	color : #93a1a1;
 	background-color: #002b36;
+	selection-background-color: #93a1a1;
+  	selection-color: #93a1a1;
+  	alternate-background-color: #93a1a1;
 }
 
 #frame {
@@ -18,7 +21,7 @@
 	background-color: #002b36;
 	border: 6px solid #268bd2;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:640px;
 	max-width:640px;
 }
@@ -35,14 +38,14 @@
 #settingsButton {
 	color : #268bd2;
 	background-color: #002b36;
-  padding: 4px;
+	padding: 4px;
 
-  /* Respect the frame border */
-  margin: 6px 6px 0px 0px;
-  border-top-right-radius: 6px;
-  border-bottom-left-radius: 10px;
+	/* Respect the frame border */
+	margin: 6px 6px 0px 0px;
+	border-top-right-radius: 6px;
+	border-bottom-left-radius: 10px;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:13px;
 	min-height:13px;
 	max-width:13px;

--- a/data/themes/SolarizedDarkCyan.qss
+++ b/data/themes/SolarizedDarkCyan.qss
@@ -7,9 +7,12 @@
  */
 
 * {
-  border: none;
+	border: none;
 	color : #93a1a1;
 	background-color: #002b36;
+	selection-background-color: #93a1a1;
+  	selection-color: #93a1a1;
+  	alternate-background-color: #93a1a1;
 }
 
 #frame {
@@ -18,7 +21,7 @@
 	background-color: #002b36;
 	border: 6px solid #2aa198;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:640px;
 	max-width:640px;
 }
@@ -35,14 +38,14 @@
 #settingsButton {
 	color : #2aa198;
 	background-color: #002b36;
-  padding: 4px;
+	padding: 4px;
 
-  /* Respect the frame border */
-  margin: 6px 6px 0px 0px;
-  border-top-right-radius: 6px;
-  border-bottom-left-radius: 10px;
+	/* Respect the frame border */
+	margin: 6px 6px 0px 0px;
+	border-top-right-radius: 6px;
+	border-bottom-left-radius: 10px;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:13px;
 	min-height:13px;
 	max-width:13px;

--- a/data/themes/SolarizedDarkGreen.qss
+++ b/data/themes/SolarizedDarkGreen.qss
@@ -7,9 +7,12 @@
  */
 
 * {
-  border: none;
+	border: none;
 	color : #93a1a1;
 	background-color: #002b36;
+	selection-background-color: #93a1a1;
+  	selection-color: #93a1a1;
+  	alternate-background-color: #93a1a1;
 }
 
 #frame {
@@ -18,7 +21,7 @@
 	background-color: #002b36;
 	border: 6px solid #859900;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:640px;
 	max-width:640px;
 }
@@ -35,14 +38,14 @@
 #settingsButton {
 	color : #859900;
 	background-color: #002b36;
-  padding: 4px;
+	padding: 4px;
 
-  /* Respect the frame border */
-  margin: 6px 6px 0px 0px;
-  border-top-right-radius: 6px;
-  border-bottom-left-radius: 10px;
+	/* Respect the frame border */
+	margin: 6px 6px 0px 0px;
+	border-top-right-radius: 6px;
+	border-bottom-left-radius: 10px;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:13px;
 	min-height:13px;
 	max-width:13px;

--- a/data/themes/SolarizedDarkMagenta.qss
+++ b/data/themes/SolarizedDarkMagenta.qss
@@ -7,9 +7,12 @@
  */
 
 * {
-  border: none;
+	border: none;
 	color : #93a1a1;
 	background-color: #002b36;
+	selection-background-color: #93a1a1;
+  	selection-color: #93a1a1;
+  	alternate-background-color: #93a1a1;
 }
 
 #frame {
@@ -18,7 +21,7 @@
 	background-color: #002b36;
 	border: 6px solid #d33682;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:640px;
 	max-width:640px;
 }
@@ -35,14 +38,14 @@
 #settingsButton {
 	color : #d33682;
 	background-color: #002b36;
-  padding: 4px;
+	padding: 4px;
 
-  /* Respect the frame border */
-  margin: 6px 6px 0px 0px;
-  border-top-right-radius: 6px;
-  border-bottom-left-radius: 10px;
+	/* Respect the frame border */
+	margin: 6px 6px 0px 0px;
+	border-top-right-radius: 6px;
+	border-bottom-left-radius: 10px;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:13px;
 	min-height:13px;
 	max-width:13px;

--- a/data/themes/SolarizedDarkOrange.qss
+++ b/data/themes/SolarizedDarkOrange.qss
@@ -7,9 +7,12 @@
  */
 
 * {
-  border: none;
+	border: none;
 	color : #93a1a1;
 	background-color: #002b36;
+	selection-background-color: #93a1a1;
+  	selection-color: #93a1a1;
+  	alternate-background-color: #93a1a1;
 }
 
 #frame {
@@ -18,7 +21,7 @@
 	background-color: #002b36;
 	border: 6px solid #cb4b16;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:640px;
 	max-width:640px;
 }
@@ -35,14 +38,14 @@
 #settingsButton {
 	color : #cb4b16;
 	background-color: #002b36;
-  padding: 4px;
+	padding: 4px;
 
-  /* Respect the frame border */
-  margin: 6px 6px 0px 0px;
-  border-top-right-radius: 6px;
-  border-bottom-left-radius: 10px;
+	/* Respect the frame border */
+	margin: 6px 6px 0px 0px;
+	border-top-right-radius: 6px;
+	border-bottom-left-radius: 10px;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:13px;
 	min-height:13px;
 	max-width:13px;

--- a/data/themes/SolarizedDarkRed.qss
+++ b/data/themes/SolarizedDarkRed.qss
@@ -10,6 +10,9 @@
   border: none;
 	color : #93a1a1;
 	background-color: #002b36;
+	selection-background-color: #93a1a1;
+  	selection-color: #93a1a1;
+  	alternate-background-color: #93a1a1;
 }
 
 #frame {
@@ -18,7 +21,7 @@
 	background-color: #002b36;
 	border: 6px solid #dc322f;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:640px;
 	max-width:640px;
 }
@@ -35,14 +38,14 @@
 #settingsButton {
 	color : #dc322f;
 	background-color: #002b36;
-  padding: 4px;
+	padding: 4px;
 
-  /* Respect the frame border */
-  margin: 6px 6px 0px 0px;
-  border-top-right-radius: 6px;
-  border-bottom-left-radius: 10px;
+	/* Respect the frame border */
+	margin: 6px 6px 0px 0px;
+	border-top-right-radius: 6px;
+	border-bottom-left-radius: 10px;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:13px;
 	min-height:13px;
 	max-width:13px;

--- a/data/themes/SolarizedDarkViolet.qss
+++ b/data/themes/SolarizedDarkViolet.qss
@@ -7,9 +7,12 @@
  */
 
 * {
-  border: none;
+	border: none;
 	color : #93a1a1;
 	background-color: #002b36;
+	selection-background-color: #93a1a1;
+  	selection-color: #93a1a1;
+  	alternate-background-color: #93a1a1;
 }
 
 #frame {
@@ -18,7 +21,7 @@
 	background-color: #002b36;
 	border: 6px solid #6c71c4;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:640px;
 	max-width:640px;
 }
@@ -35,14 +38,14 @@
 #settingsButton {
 	color : #6c71c4;
 	background-color: #002b36;
-  padding: 4px;
+	padding: 4px;
 
-  /* Respect the frame border */
-  margin: 6px 6px 0px 0px;
-  border-top-right-radius: 6px;
-  border-bottom-left-radius: 10px;
+	/* Respect the frame border */
+	margin: 6px 6px 0px 0px;
+	border-top-right-radius: 6px;
+	border-bottom-left-radius: 10px;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:13px;
 	min-height:13px;
 	max-width:13px;

--- a/data/themes/SolarizedDarkYellow.qss
+++ b/data/themes/SolarizedDarkYellow.qss
@@ -7,9 +7,12 @@
  */
 
 * {
-  border: none;
+	border: none;
 	color : #93a1a1;
 	background-color: #002b36;
+	selection-background-color: #93a1a1;
+  	selection-color: #93a1a1;
+  	alternate-background-color: #93a1a1;
 }
 
 #frame {
@@ -18,7 +21,7 @@
 	background-color: #002b36;
 	border: 6px solid #b58900;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:640px;
 	max-width:640px;
 }
@@ -35,14 +38,14 @@
 #settingsButton {
 	color : #b58900;
 	background-color: #002b36;
-  padding: 4px;
+	padding: 4px;
 
-  /* Respect the frame border */
-  margin: 6px 6px 0px 0px;
-  border-top-right-radius: 6px;
-  border-bottom-left-radius: 10px;
+	/* Respect the frame border */
+	margin: 6px 6px 0px 0px;
+	border-top-right-radius: 6px;
+	border-bottom-left-radius: 10px;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:13px;
 	min-height:13px;
 	max-width:13px;

--- a/data/themes/Yosemite Dark.qss
+++ b/data/themes/Yosemite Dark.qss
@@ -7,11 +7,14 @@
  */
 
 * {
-  border: none;
-  font-family:"DejaVu Sans";
-  font-weight: 200;
+	border: none;
+	font-family:"DejaVu Sans";
+	font-weight: 200;
 	color : #ffffff;
 	background-color: #f4000000;
+	selection-background-color: #ffffff;
+  	selection-color: #ffffff;
+  	alternate-background-color: #ffffff;
 }
 
 #frame {
@@ -20,7 +23,7 @@
 	background-color: #f4000000;
 	border: 1px solid #20808080;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:640px;
 	max-width:640px;
 }
@@ -35,9 +38,9 @@
 #settingsButton {
 	color: #484848;
 	background-color: transparent;
-  padding: 8px;
+	padding: 8px;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:14px;
 	min-height:14px;
 	max-width:14px;

--- a/data/themes/Yosemite.qss
+++ b/data/themes/Yosemite.qss
@@ -7,11 +7,14 @@
  */
 
 * {
-  border: none;
-  font-family:"DejaVu Sans";
-  font-weight: 200;
+	border: none;
+	font-family:"DejaVu Sans";
+	font-weight: 200;
 	color : #000000;
 	background-color: #fcfcfc;
+	selection-background-color: #000000;
+  	selection-color: #000000;
+  	alternate-background-color: #000000;
 }
 
 #frame {
@@ -20,7 +23,7 @@
 	background-color: #fcfcfc;
 	border: 1px solid #20808080;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:640px;
 	max-width:640px;
 }
@@ -35,9 +38,9 @@
 #settingsButton {
 	color: #bdbdbd;
 	background-color: transparent;
-  padding: 8px;
+	padding: 8px;
 
-  /* Workaround for Qt to get fixed size button*/
+	/* Workaround for Qt to get fixed size button*/
 	min-width:14px;
 	min-height:14px;
 	max-width:14px;

--- a/src/application/src/main.cpp
+++ b/src/application/src/main.cpp
@@ -66,7 +66,7 @@ int main(int argc, char **argv) {
         app = new QApplication(argc, argv);
         app->setApplicationName("albert");
         app->setApplicationDisplayName("Albert");
-        app->setApplicationVersion("v0.9.2");
+        app->setApplicationVersion("v0.9.3");
         app->setQuitOnLastWindowClosed(false);
         QString icon = XdgIconLookup::iconPath("albert");
         if ( icon.isEmpty() ) icon = ":app_icon";

--- a/src/application/src/mainwindow/actionlist.cpp
+++ b/src/application/src/mainwindow/actionlist.cpp
@@ -65,6 +65,6 @@ void ActionList::ActionDelegate::paint(QPainter *painter, const QStyleOptionView
     // Draw text
     painter->setFont(option.font);
     QString text = QFontMetrics(option.font).elidedText(index.data(Qt::DisplayRole).toString(), option.textElideMode, option.rect.width());
-    option.widget->style()->drawItemText(painter, option.rect, Qt::AlignCenter|Qt::AlignHCenter, option.palette, option.state & QStyle::State_Enabled, text, QPalette::WindowText);
+    option.widget->style()->drawItemText(painter, option.rect, Qt::AlignCenter|Qt::AlignHCenter, option.palette, option.state & QStyle::State_Enabled, text, (option.state & QStyle::State_Selected) ? QPalette::Highlight : QPalette::WindowText);
     painter->restore();
 }

--- a/src/application/src/mainwindow/proposallist.cpp
+++ b/src/application/src/mainwindow/proposallist.cpp
@@ -210,14 +210,14 @@ void ProposalList::ItemDelegate::paint(QPainter *painter, const QStyleOptionView
 
     // Draw display role
     painter->setFont(font1);
-    QString text = fontMetrics1.elidedText(index.data(Qt::DisplayRole).toString(), option.textElideMode, textRect.width());
-    option.widget->style()->drawItemText(painter, textRect, option.displayAlignment, option.palette, option.state & QStyle::State_Enabled, text, QPalette::WindowText);
+    QString text = fontMetrics1.elidedText(index.data(Qt::DisplayRole).toString(), option.textElideMode, textRect.width());    
+    option.widget->style()->drawItemText(painter, textRect, option.displayAlignment, option.palette, option.state & QStyle::State_Enabled, text, (option.state & QStyle::State_Selected) ? QPalette::Highlight : QPalette::WindowText);
     //    painter->drawText(textRect, Qt::AlignTop|Qt::AlignLeft, text);
 
     // Draw tooltip role
     painter->setFont(font2);
     text = fontMetrics2.elidedText(index.data(option.state.testFlag(QStyle::State_Selected)? subTextRole : Qt::ToolTipRole).toString(), option.textElideMode, subTextRect.width());
-    painter->drawText(subTextRect   , Qt::AlignBottom|Qt::AlignLeft, text);
+    option.widget->style()->drawItemText(painter, subTextRect, Qt::AlignBottom|Qt::AlignLeft, option.palette, option.state & QStyle::State_Enabled, text, (option.state & QStyle::State_Selected) ? QPalette::HighlightedText : QPalette::AlternateBase);
 
     painter->restore();
 }


### PR DESCRIPTION
This is a PR to change the way the `proposal` and `action` list selected items are rendered. I'm introducing the usage of three more qss styles:

        QListView#proposalList {
                // Change the TEXT color of the selected proposal item
                selection-background-color: #727A8F;

                // Change the SUBTEXT text color of the selected proposal item
                selection-color: #727A8F;

                // Change the text color of the general proposal item (not selected)
                alternate-background-color: #727A8F;
        }

The same can be used in action list (only `selection-background-color`, since there is no subtext in action list items)


        QListView#actionList {	
                // Change the TEXT color of the selected action list item
                selection-background-color: #727A8F;
        }

This way we can have themes like this:

![image](https://cloud.githubusercontent.com/assets/1160365/22862985/799ac6f2-f117-11e6-93a1-fa92f058ccc6.png)

Or this:

![image](https://cloud.githubusercontent.com/assets/1160365/22863131/8b291408-f119-11e6-8426-133c1a493c73.png)


This does change the way theme works, but in this PR I've already fixed all themes. I've also fixed the themes templates so it can reflect this changes.

Please do let me know if there is a problem with this PR.