### PR TITLE
IPC socket in users' cache directory

### DIFF
--- a/src/application/src/main.cpp
+++ b/src/application/src/main.cpp
@@ -72,6 +72,7 @@ int main(int argc, char **argv) {
         if ( icon.isEmpty() ) icon = ":app_icon";
         app->setWindowIcon(QIcon(icon));
 
+        QString socketPath = QStandardPaths::writableLocation(QStandardPaths::CacheLocation)+"/socket";
 
 
         /*
@@ -94,7 +95,7 @@ int main(int argc, char **argv) {
 
         const QStringList args = parser.positionalArguments();
         QLocalSocket socket;
-        socket.connectToServer(app->applicationName());
+        socket.connectToServer(socketPath);
         if ( socket.waitForConnected(500) ) {
             // If there is a command send it
             if ( args.count() == 1 ){
@@ -241,10 +242,10 @@ int main(int argc, char **argv) {
          */
 
         // Remove pipes potentially leftover after crash
-        QLocalServer::removeServer(app->applicationName());
+        QLocalServer::removeServer(socketPath);
 
         // Create server and handle messages
-        if ( !localServer->listen(app->applicationName()) )
+        if ( !localServer->listen(socketPath) )
             qWarning() << "Local server could not be created. IPC will not work! Reason:" << localServer->errorString();
 
         // Handle incomin messages

--- a/src/application/src/main.cpp
+++ b/src/application/src/main.cpp
@@ -28,7 +28,6 @@
 #include <QStandardPaths>
 #include <QtNetwork/QLocalServer>
 #include <QtNetwork/QLocalSocket>
-#include <random>
 #include <csignal>
 #include "mainwindow.h"
 #include "hotkeymanager.h"
@@ -241,15 +240,11 @@ int main(int argc, char **argv) {
          *  START IPC SERVER
          */
 
-        // Get a unique name for the server
-        QString uid;
-        std::string charset = "abcdefghijklmnaoqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
-        std::mt19937_64 gen {std::random_device()()};
-        std::uniform_int_distribution<size_t> dist {0, charset.length()-1};
-        std::generate_n(std::back_inserter(uid), 6, [&] { return charset[dist(gen)]; });
+        // Remove pipes potentially leftover after crash
+        QLocalServer::removeServer(app->applicationName());
 
         // Create server and handle messages
-        if ( !localServer->listen(QString("%1.%2").arg(app->applicationName()).arg(uid)) )
+        if ( !localServer->listen(app->applicationName()) )
             qWarning() << "Local server could not be created. IPC will not work! Reason:" << localServer->errorString();
 
         // Handle incomin messages


### PR DESCRIPTION
Solved #411 in a easy way.

It uses the users' cache directory (mostly `~/.cache/albert/socket`) instead of `/tmp/albert` or some weird tempfile-names.

Therefore it allows easy finding of the corresponding socket while also staying avoiding namespace-confilicts in `/tmp` when multiple users execute albert.