### PR TITLE
use screenGeometry instead of availableGeometry

### DIFF
--- a/src/lib/albert/src/albert/mainwindow/mainwindow.cpp
+++ b/src/lib/albert/src/albert/mainwindow/mainwindow.cpp
@@ -208,7 +208,7 @@ void MainWindow::setVisible(bool visible) {
         // flicker this may be okay.
         if (showCentered_){
             QDesktopWidget *dw = QApplication::desktop();
-            this->move(dw->availableGeometry(dw->screenNumber(QCursor::pos())).center()
+            this->move(dw->screenGeometry(dw->screenNumber(QCursor::pos())).center()
                        -QPoint(rect().right()/2,192 ));
         }
         this->raise();


### PR DESCRIPTION
This is a workaround for a bug by Qt.

After adding new monitors, QDesktopWidget is not able to calculate availableGeometry() on the new monitor correctly.