### PR TITLE
Fixed broken badge image URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Albert [![Build Status](https://api.travis-ci.org/albertlauncher/albert.svg?branch=dev)](https://travis-ci.org/albertlauncher/albert)
 
 [![IRC](https://img.shields.io/badge/chat-on%20freenode-brightgreen.svg)](http://webchat.freenode.net/?channels=%23albertlauncher)
-[![Telegram news channel](https://img.shields.io/badge/news channel-telegram-0088cc.svg?style=flat)](https://telegram.me/albertlauncher)
+[![Telegram news channel](https://img.shields.io/badge/news%20channel-telegram-0088cc.svg?style=flat)](https://telegram.me/albertlauncher)
 [![Telegram community chat](https://img.shields.io/badge/chat-telegram-0088cc.svg?style=flat)](https://telegram.me/albert_launcher_community)
 
 Access everything with virtually zero effort. Run applications, open files or their paths, open bookmarks in your browser, search the web, calculate things and a lot more. See the [docs](https://albertlauncher.github.io/docs) for more information.


### PR DESCRIPTION
The badge image URL for Telegram news channel contains a space character which results in a broken image. 

```
https://img.shields.io/badge/news channel-telegram-0088cc.svg?style=flat
```

Replacing the space character by URL encoded `%20` fixes the issue.