### PR TITLE
[feature] launch albert using super/meta key

### DIFF
--- a/src/lib/albert/src/albert/albert.cpp
+++ b/src/lib/albert/src/albert/albert.cpp
@@ -341,7 +341,7 @@ int Albert::run(int argc, char **argv) {
         Core::ExtensionManager::instance->reloadExtensions();
 
         // Application is initialized create the settings widget
-        settingsWidget   = new SettingsWidget(mainWindow, hotkeyManager, ExtensionManager::instance, trayIcon);
+        settingsWidget = new SettingsWidget(mainWindow, hotkeyManager, ExtensionManager::instance, trayIcon);
 
         // If somebody requested the settings dialog open it
         if ( showSettingsWhenInitialized )

--- a/src/lib/albert/src/albert/settingswidget/grabkeybutton.cpp
+++ b/src/lib/albert/src/albert/settingswidget/grabkeybutton.cpp
@@ -77,6 +77,7 @@ void GrabKeyButton::keyPressEvent(QKeyEvent *event) {
             releaseAll(); // Can not be before since window closes on esc
             return;
         }
+
         releaseAll();
 
         setText(QKeySequence((mods&~Qt::GroupSwitchModifier)|key).toString()); //QTBUG-45568
@@ -87,15 +88,18 @@ void GrabKeyButton::keyPressEvent(QKeyEvent *event) {
 }
 
 
-
 /** ***************************************************************************/
 void GrabKeyButton::keyReleaseEvent(QKeyEvent *event) {
     if ( waitingForHotkey_ ) {
         // Modifier released -> update the label
         int key = event->key();
-        if(key == Qt::Key_Control || key == Qt::Key_Shift || key == Qt::Key_Alt || key == Qt::Key_Meta) {
+        if(key == Qt::Key_Control || key == Qt::Key_Shift || key == Qt::Key_Alt) {
             setText(QKeySequence((event->modifiers()&~Qt::GroupSwitchModifier)|Qt::Key_Question).toString());//QTBUG-45568
             event->accept();
+            return;
+        } else if ( key == Qt::Key_Meta ) {
+            releaseAll();
+            emit keyCombinationPressed(key);
             return;
         }
         return;

--- a/src/lib/albert/src/albert/settingswidget/settingswidget.cpp
+++ b/src/lib/albert/src/albert/settingswidget/settingswidget.cpp
@@ -267,10 +267,12 @@ void SettingsWidget::updatePluginInformations(const QModelIndex & current) {
 
 /** ***************************************************************************/
 void SettingsWidget::changeHotkey(int newhk) {
+
     int oldhk = *hotkeyManager_->hotkeys().begin(); //TODO Make cool sharesdpointer design
 
     // Try to set the hotkey
     if (hotkeyManager_->registerHotkey(newhk)) {
+
         QString hkText(QKeySequence((newhk&~Qt::GroupSwitchModifier)).toString());//QTBUG-45568
         ui.grabKeyButton_hotkey->setText(hkText);
         QSettings(qApp->applicationName()).setValue("hotkey", hkText);

--- a/src/lib/albert/src/albert/settingswidget/settingswidget.cpp
+++ b/src/lib/albert/src/albert/settingswidget/settingswidget.cpp
@@ -70,8 +70,15 @@ SettingsWidget::SettingsWidget(MainWindow *mainWindow,
     QSet<int> hks = hotkeyManager->hotkeys();
     if (hks.size() < 1)
         ui.grabKeyButton_hotkey->setText("Press to set hotkey");
-    else
-        ui.grabKeyButton_hotkey->setText(QKeySequence(*hks.begin()).toString()); // OMG
+    else {
+        /**
+         * hacks, hacks everywhere.
+         */
+        if ( hks.toList()[0] == Qt::Key_Meta )
+            ui.grabKeyButton_hotkey->setText("Meta");
+        else
+            ui.grabKeyButton_hotkey->setText(QKeySequence(*hks.begin()).toString()); // OMG
+    }
     connect(ui.grabKeyButton_hotkey, &GrabKeyButton::keyCombinationPressed,
             this, &SettingsWidget::changeHotkey);
 
@@ -273,7 +280,12 @@ void SettingsWidget::changeHotkey(int newhk) {
     // Try to set the hotkey
     if (hotkeyManager_->registerHotkey(newhk)) {
 
-        QString hkText(QKeySequence((newhk&~Qt::GroupSwitchModifier)).toString());//QTBUG-45568
+        QString hkText;
+        if ( newhk == Qt::Key_Meta )
+            hkText = QString("Meta");
+        else
+            hkText = QString(QKeySequence((newhk&~Qt::GroupSwitchModifier)).toString());//QTBUG-45568
+
         ui.grabKeyButton_hotkey->setText(hkText);
         QSettings(qApp->applicationName()).setValue("hotkey", hkText);
         hotkeyManager_->unregisterHotkey(oldhk);

--- a/src/lib/globalshortcut/src/hotkeymanager.cpp
+++ b/src/lib/globalshortcut/src/hotkeymanager.cpp
@@ -41,6 +41,17 @@ HotkeyManager::~HotkeyManager() {
 
 /** ***************************************************************************/
 bool HotkeyManager::registerHotkey(const QString &hk) {
+    /**
+     * QKeySequence doesn't play nicely with a lone "Meta".
+     *
+     * for some reason, it only work in combination with another
+     * key.
+     * 
+     * so here's a little magic to work around it.
+     */
+    if ( hk == "Meta" )
+        return registerHotkey(QKeySequence(Qt::Key_Meta));
+
 	return registerHotkey(QKeySequence(hk));
 }
 

--- a/src/lib/globalshortcut/src/hotkeymanager_x11.cpp
+++ b/src/lib/globalshortcut/src/hotkeymanager_x11.cpp
@@ -54,7 +54,7 @@ namespace {
         { Qt::Key_PageDown,     { XK_Next }},
         { Qt::Key_Shift,        { XK_Shift_L, XK_Shift_R, XK_Shift_Lock  }},// modifiers
         { Qt::Key_Control,      { XK_Control_L, XK_Control_R }},
-        { Qt::Key_Meta,         { XK_Meta_L, XK_Meta_R }},
+        { Qt::Key_Meta,         { XK_Super_L, XK_Super_R }}, // XK_Meta_L Maps to alt, not super(win) key
         { Qt::Key_Alt,          { XK_Alt_L, XK_Alt_R }},
         { Qt::Key_CapsLock,     { XK_Caps_Lock }},
         { Qt::Key_NumLock,      { XK_Num_Lock }},


### PR DESCRIPTION
# Description  
This patch will let users launch Albert by tapping Meta/Super/Windows key.

# Note
The current architecture reacts to the 'key press', hence as soon as the meta key is pressed, Albert will be launched. This may be an issue for those people who using Meta + other combinations for their desktop.

addresses #422 and #201.