### PR TITLE
use rpath for dependent libs

### DIFF
--- a/src/lib/albert/CMakeLists.txt
+++ b/src/lib/albert/CMakeLists.txt
@@ -51,5 +51,8 @@ target_link_libraries(${PROJECT_NAME}
         xdg
 )
 
+# Set the RPATH so that libraries get found
+set_target_properties(${PROJECT_NAME} PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib/albert")
+
 # Install target
 install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION lib/albert)

--- a/src/lib/globalshortcut/CMakeLists.txt
+++ b/src/lib/globalshortcut/CMakeLists.txt
@@ -44,5 +44,8 @@ target_include_directories(${PROJECT_NAME}
 # Link target to libraries
 target_link_libraries(${PROJECT_NAME} PRIVATE ${LIB})
 
+# Set the RPATH so that libraries get found
+set_target_properties(${PROJECT_NAME} PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib/albert")
+
 # Install target
 install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION lib/albert)


### PR DESCRIPTION
Fixes #437 

Before merging this PR: Why is an additional runpath not needed for the plugins, although these require globalshortcut and xdg directly?