### PR TITLE
Generate AppImage, closes #407

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ script:
   - sudo cp ./appdir/usr/lib/* /usr/lib/
   - export LD_LIBRARY_PATH=/opt/qt58/lib/
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
+  - mv appdir/usr/share/albert/themes appdir/usr/plugins/styles
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage
   - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
   - curl --upload-file ./Albert*.AppImage https://transfer.sh/Albert-git.$(git rev-parse --short HEAD)-x86_64.AppImage

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script:
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 
   - chmod a+x linuxdeployqt*.AppImage
   - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
-  - export LD_LIBRARY_PATH=appdir/usr/lib/albert/plugins/:appdir/usr/lib/albert/:$LD_LIBRARY_PATH
+  - export LD_LIBRARY_PATH=appdir/usr/lib/:$LD_LIBRARY_PATH
   - find appdir/usr/lib/albert/ -name '*.so*' -exec mv {} appdir/usr/lib/ \;
   - rm -rf appdir/usr/lib/albert
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,20 @@ before_install:
 before_script:
   - mkdir build
   - cd build
-  - cmake ..  -DCMAKE_BUILD_TYPE=Release 
+  - cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr
   
 script:
-    - make
-    # Test installation process
-    - make DESTDIR=/tmp/albertbuild install
-    
+  - make
+  # Test installation process
+  - make DESTDIR=appdir install ; find appdir/
+  - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 
+  - chmod a+x linuxdeployqt*.AppImage
+  - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage
+  - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
+  - curl --upload-file ./Albert*.AppImage https://transfer.sh/Albert-git.$(git rev-parse --short HEAD)-x86_64.AppImage
+
 notifications:
   irc:
     channels:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
     - sudo apt-get update -qq
     
 install: 
-    - sudo apt-get -y install qt58base qt58Svg libmuparser-dev
+    - sudo apt-get -y install qt58base qt58Svg qt58x11extras libmuparser-dev
     - source /opt/qt*/bin/qt*-env.sh
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,12 @@ compiler:
   - gcc
 
 before_install:
-    - sudo apt-get install -qq cmake qtbase5-dev libqt5x11extras5-dev libqt5svg5-dev libmuparser-dev
- 
-before_script:
-  - mkdir build
-  - cd build
-  - cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr
+    - sudo add-apt-repository ppa:beineri/opt-qt58-trusty -y
+    - sudo apt-get update -qq
+    
+install: 
+    - sudo apt-get -y install qt58base qt58Svg libmuparser-dev
+    - source /opt/qt*/bin/qt*-env.sh
   
 script:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ script:
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 
   - chmod a+x linuxdeployqt*.AppImage
   - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
-  - find appdir/usr/lib/albert/ -name '*.so*' -exec mv {} . \;
-  - sudo mv "*.so*" /usr/lib
+  - find appdir/usr/lib/albert/ -name '*.so*' -exec mv {} ./appdir/usr/lib \;
+  - sudo cp ./appdir/usr/lib/* /usr/lib/
   - rm -rf appdir/usr/lib/albert
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ script:
   - find appdir/usr/lib/albert/ -name '*.so*' -exec mv {} ./appdir/usr/lib \;
   - rm -rf appdir/usr/lib/albert
   - sudo cp ./appdir/usr/lib/* /usr/lib/
+  - export LD_LIBRARY_PATH=/opt/qt58/lib/
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage
   - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,11 @@ before_install:
 install: 
     - sudo apt-get -y install qt58base qt58Svg libmuparser-dev
     - source /opt/qt*/bin/qt*-env.sh
+
+before_script:
+  - mkdir build
+  - cd build
+  - cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr
   
 script:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ script:
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 
   - chmod a+x linuxdeployqt*.AppImage
   - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
+  - export LD_LIBRARY_PATH=appdir/usr/lib/albert/plugins/:appdir/usr/lib/albert/:$LD_LIBRARY_PATH
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage
   - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ script:
   - chmod a+x linuxdeployqt*.AppImage
   - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
   - find appdir/usr/lib/albert/ -name '*.so*' -exec mv {} ./appdir/usr/lib \;
-  - sudo cp ./appdir/usr/lib/* /usr/lib/
   - rm -rf appdir/usr/lib/albert
+  - sudo cp ./appdir/usr/lib/* /usr/lib/
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage
   - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ script:
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 
   - chmod a+x linuxdeployqt*.AppImage
   - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
-  - export LD_LIBRARY_PATH=appdir/usr/lib/:$LD_LIBRARY_PATH
-  - find appdir/usr/lib/albert/ -name '*.so*' -exec mv {} appdir/usr/lib/ \;
+  - find appdir/usr/lib/albert/ -name '*.so*' -exec mv {} . \;
+  - sudo mv "*.so*" /usr/lib
   - rm -rf appdir/usr/lib/albert
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ script:
   - chmod a+x linuxdeployqt*.AppImage
   - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
   - export LD_LIBRARY_PATH=appdir/usr/lib/albert/plugins/:appdir/usr/lib/albert/:$LD_LIBRARY_PATH
+  - find appdir/usr/lib/albert/ -name '*.so*' -exec mv {} appdir/usr/lib/ \;
+  - rm -rf appdir/usr/lib/albert
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage
   - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq


### PR DESCRIPTION
This PR, when merged, will compile this application on [Travis CI](https://travis-ci.org/) upon each `git push`, and upload an [AppImage](http://appimage.org/) to a temporary download URL on transfer.sh (available for 14 days). The download URL is toward the end of each Travis CI build log of each build (see below for how to set up automatic uploading to your GitHub Releases page).

For this to work, you need to enable Travis CI for your repository as [described here](https://travis-ci.org/getting_started) __prior to merging this__, if you haven't already done so.

Providing an [AppImage](http://appimage.org/) would have, among others, these advantages:
- Works for most Linux distributions (including Ubuntu, Fedora, openSUSE, CentOS, elementaryOS, Linux Mint, and others)
- One app = one file = super simple for users: just download one AppImage file, [make it executable](http://discourse.appimage.org/t/how-to-make-an-appimage-executable/80), and run
- No unpacking or installation necessary
- No root needed
- No system libraries changed
- Works out of the box, no installation of runtimes needed
- Optional desktop integration with `appimaged`
- Optional binary delta updates, e.g., for continuous builds (only download the binary diff) using AppImageUpdate
- Can optionally GPG2-sign your AppImages (inside the file)
- Works on Live ISOs
- Can use the same AppImages when dual-booting multiple distributions

[Here is an overview](https://github.com/probonopd/AppImageKit/wiki/AppImages) of projects that are already distributing upstream-provided, official AppImages.

__Please note:__ Instead of storing AppImage builds temporarily for 14 days each on transfer.sh, you could use GitHub Releases to store the binaries permanently. This way, they would be visible on the Releases page of your project. This is what I recommend. See https://docs.travis-ci.com/user/deployment/releases/. If you want to do this for continuous builds, also see https://github.com/probonopd/uploadtool.

If you would like to see only one entry for the Pull Request in your project's history, then please enable [this GitHub functionality](https://help.github.com/articles/configuring-commit-squashing-for-pull-requests/) on your repo. It allows you to squash (combine) the commits when merging.

If you have questions, AppImage developers are on #AppImage on irc.freenode.net.

__NOTE:__ This is currently affected by https://github.com/albertlauncher/albert/issues/198 which needs to be solved for the resulting AppImage to work properly.