### PR TITLE
Add exec as an application keyword

### DIFF
--- a/src/plugins/applications/src/main.cpp
+++ b/src/plugins/applications/src/main.cpp
@@ -452,6 +452,7 @@ vector<shared_ptr<StandardIndexItem>> indexApplications(bool ignoreShowInKeys) {
             // Set keywords
             vector<Indexable::WeightedKeyword> indexKeywords;
             indexKeywords.emplace_back(name, USHRT_MAX);
+            indexKeywords.emplace_back(exec, USHRT_MAX);
             if (!genericName.isEmpty())
                 indexKeywords.emplace_back(genericName, USHRT_MAX*0.9);
             for (auto & kw : keywords)


### PR DESCRIPTION
A small addition for your consideration. As the change suggests, this allows to search applications by executable name. So for example one could start typing "evince" for the gnome document viewer, regardless of what the name under the current localization might be.