### PR TITLE
Receive KeyPress events that otherwise be ignored

### DIFF
--- a/src/lib/globalshortcut/src/hotkeymanager_x11.cpp
+++ b/src/lib/globalshortcut/src/hotkeymanager_x11.cpp
@@ -114,6 +114,11 @@ namespace {
         return 0;
     }
 
+    static int XSelectInputErrorHandler(Display *, XErrorEvent *e) {
+        qWarning() << "XSelectInputError: "<< e->type;
+        return 0;
+    }
+
 
 //    /** ***********************************************************************/
 //    class XLibManager
@@ -250,8 +255,14 @@ HotkeyManagerPrivate::HotkeyManagerPrivate(QObject *parent)
             }
         }
 
+        // Set own errorhandler to guard agains BadWindow errors
+        XErrorHandler savedErrorHandler = XSetErrorHandler(XSelectInputErrorHandler);
+
         // Register to receive KeyPress events that otherwise be swallowed
         XSelectInput(QX11Info::display(), QX11Info::appRootWindow(), KeyPressMask);
+
+        // Reset errorhandler
+        XSetErrorHandler(savedErrorHandler);
     }
     else {
         // assume defaults

--- a/src/lib/globalshortcut/src/hotkeymanager_x11.cpp
+++ b/src/lib/globalshortcut/src/hotkeymanager_x11.cpp
@@ -249,6 +249,9 @@ HotkeyManagerPrivate::HotkeyManagerPrivate(QObject *parent)
                 masks.meta = masks.hyper;
             }
         }
+
+        // Register to receive KeyPress events that otherwise be swallowed
+        XSelectInput(QX11Info::display(), QX11Info::appRootWindow(), KeyPressMask);
     }
     else {
         // assume defaults


### PR DESCRIPTION
Whenever an application has a shortcut bound to a modifier (e.g. the
`Super` key), and the Albert launcher uses a shortcut based on the same
key, but as a modifier (e.g. `<Super>+Space`), Albert needs to register
to capture the KeyPress event that would otherwise be dealt with on the
other application and thus ignored by Albert.

This fix allows Albert to honor shortcuts that use modifiers bound to
other applications.