### PR TITLE
Add a little label which displays error messages

### DIFF
--- a/src/plugins/externalextensions/configwidget.ui
+++ b/src/plugins/externalextensions/configwidget.ui
@@ -55,6 +55,53 @@
      </attribute>
     </widget>
    </item>
+   <item>
+    <widget class="QLabel" name="errorLabel">
+     <property name="palette">
+      <palette>
+       <active>
+        <colorrole role="WindowText">
+         <brush brushstyle="SolidPattern">
+          <color alpha="255">
+           <red>255</red>
+           <green>0</green>
+           <blue>0</blue>
+          </color>
+         </brush>
+        </colorrole>
+       </active>
+       <inactive>
+        <colorrole role="WindowText">
+         <brush brushstyle="SolidPattern">
+          <color alpha="255">
+           <red>255</red>
+           <green>0</green>
+           <blue>0</blue>
+          </color>
+         </brush>
+        </colorrole>
+       </inactive>
+       <disabled>
+        <colorrole role="WindowText">
+         <brush brushstyle="SolidPattern">
+          <color alpha="255">
+           <red>165</red>
+           <green>167</green>
+           <blue>169</blue>
+          </color>
+         </brush>
+        </colorrole>
+       </disabled>
+      </palette>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <resources/>

--- a/src/plugins/externalextensions/src/main.cpp
+++ b/src/plugins/externalextensions/src/main.cpp
@@ -39,7 +39,7 @@ public:
     QStringList pluginDirs;
     std::vector<std::unique_ptr<ExternalExtension>> externalExtensions;
     QFileSystemWatcher fileSystemWatcher;
-    QString errorString;
+    QStringList errors;
     QPointer<ConfigWidget> widget;
 };
 
@@ -88,7 +88,8 @@ QWidget *ExternalExtensions::Extension::widget(QWidget *parent) {
 
         ExternalExtensionsModel *model = new ExternalExtensionsModel(d->externalExtensions, d->widget->ui.tableView);
         d->widget->ui.tableView->setModel(model);
-        d->widget->ui.errorLabel->setText(d->errorString);
+        d->widget->ui.errorLabel->setText(QString("There were %1 errors.").arg(d->errors.size()));
+        d->widget->ui.errorLabel->setToolTip(d->errors.join("\n"));
 
         connect(d->widget->ui.tableView, &QTableView::activated,
                 model, &ExternalExtensionsModel::onActivated);
@@ -117,7 +118,7 @@ void ExternalExtensions::Extension::reloadExtensions() {
         d->fileSystemWatcher.removePaths(d->fileSystemWatcher.files());
 
     // Clear error label
-    d->errorString = "";
+    d->errors.clear();
 
     // Iterate over all files in the plugindirs
     for (const QString &pluginDir : d->pluginDirs) {
@@ -139,7 +140,7 @@ void ExternalExtensions::Extension::reloadExtensions() {
                 d->fileSystemWatcher.addPath(path);
             } catch ( QString s ) {
                 qWarning("Failed to initialize external extension: %s", s.toLocal8Bit().data());
-                d->errorString += "Failed to initialize " + id + ": " + s + "\n";
+                d->errors.append("Failed to initialize " + id + ": " + s + "\n");
             }
         }
     }


### PR DESCRIPTION
Addressing the issue #489 External Extension Error:

This PR adds a red label below the list of loaded externals. Any message about an error while loading an external is being appended there. 
This could have negative effects on the overall readability of the widget in case of many errors when the label is taking too much space. But this scenario is 1. unlikely and 2. easily fixed by applying a max-height. A more sophisticated approach would be a button that appears in case of errors which opens a new log-window.