### PR TITLE
Ignore missing hotkey

### DIFF
--- a/lib/albertcore/src/core/settingswidget/settingswidget.cpp
+++ b/lib/albertcore/src/core/settingswidget/settingswidget.cpp
@@ -302,11 +302,9 @@ void SettingsWidget::closeEvent(QCloseEvent *event) {
         if ( msgBox.result() == QMessageBox::Ok ) {
             ui.tabs->setCurrentIndex(0);
             show();
+            event->ignore();
+            return;
         }
-        else
-            qApp->quit();
-        event->ignore();
-        return;
     }
     event->accept();
 }

--- a/lib/albertcore/src/core/settingswidget/settingswidget.cpp
+++ b/lib/albertcore/src/core/settingswidget/settingswidget.cpp
@@ -293,10 +293,10 @@ void SettingsWidget::keyPressEvent(QKeyEvent *event) {
 /** ***************************************************************************/
 void SettingsWidget::closeEvent(QCloseEvent *event) {
     if (hotkeyManager_->hotkeys().empty()) {
-        QMessageBox msgBox(QMessageBox::Critical, "Error",
-                           "Hotkey is invalid, please set it. Press Ok to go "\
-                           "back to the settings, or press Cancel to quit albert.",
-                           QMessageBox::Close|QMessageBox::Ok,
+        QMessageBox msgBox(QMessageBox::Warning, "Hotkey Missing",
+                           "Hotkey is invalid, please set it. Press OK to go "\
+                           "back to the settings.",
+                           QMessageBox::Ok|QMessageBox::Ignore,
                            this);
         msgBox.exec();
         if ( msgBox.result() == QMessageBox::Ok ) {


### PR DESCRIPTION
IIUC, albert should actually work without any hotkey and solely with `albert -show`. So closing the settings dialogue without setting a hotkey forces albert to close. While showing an error message about the missing hotkey and moving the tab to the hotkey after confirmation makes absolutely sense, but it does not make sense closing albert after clicking the Cancel field.