### PR TITLE
Add missing include.

### DIFF
--- a/lib/albertcore/src/core/telemetry.cpp
+++ b/lib/albertcore/src/core/telemetry.cpp
@@ -2,6 +2,7 @@
 
 #include <QApplication>
 #include <QDateTime>
+#include <QDebug>
 #include <QJsonDocument>
 #include <QMessageBox>
 #include <QNetworkAccessManager>


### PR DESCRIPTION
In certain conditions this seems to [fail to build](https://666998.bugs.gentoo.org/attachment.cgi?id=547806) with Qt 5.11.