### PR TITLE
Reinstate GPLv3 license and update copyright

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,15 @@
+## Albert - A fast and flexible keyboard launcher for Linux
+### Copyright (C) 2019  Manuel Schneider
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/include/albert/action.h
+++ b/include/albert/action.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #pragma once
 #include <QString>

--- a/include/albert/core_globals.h
+++ b/include/albert/core_globals.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #pragma once
 

--- a/include/albert/extension.h
+++ b/include/albert/extension.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #pragma once
 #include <QString>

--- a/include/albert/fallbackprovider.h
+++ b/include/albert/fallbackprovider.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #pragma once
 #include <QString>

--- a/include/albert/frontend.h
+++ b/include/albert/frontend.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #pragma once
 #include "plugin.h"

--- a/include/albert/indexable.h
+++ b/include/albert/indexable.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #pragma once
 #include <QString>

--- a/include/albert/item.h
+++ b/include/albert/item.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #pragma once
 #include <QString>

--- a/include/albert/plugin.h
+++ b/include/albert/plugin.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #pragma once
 #include <QDir>

--- a/include/albert/query.h
+++ b/include/albert/query.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #pragma once
 #include <QMutex>

--- a/include/albert/queryhandler.h
+++ b/include/albert/queryhandler.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #pragma once
 #include <QString>

--- a/include/albert/util/history.h
+++ b/include/albert/util/history.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #pragma once
 #include <QObject>

--- a/include/albert/util/itemroles.h
+++ b/include/albert/util/itemroles.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #pragma once
 #include  <Qt>

--- a/include/albert/util/offlineindex.h
+++ b/include/albert/util/offlineindex.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #pragma once
 #include <QString>

--- a/include/albert/util/shutil.h
+++ b/include/albert/util/shutil.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #pragma once
 #include <QString>

--- a/include/albert/util/standardactions.h
+++ b/include/albert/util/standardactions.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #pragma once
 #include <QUrl>

--- a/include/albert/util/standardindexitem.h
+++ b/include/albert/util/standardindexitem.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #pragma once
 #include <vector>

--- a/include/albert/util/standarditem.h
+++ b/include/albert/util/standarditem.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #pragma once
 #include <QString>

--- a/lib/globalshortcut/include/globalshortcut/globalshortcut_globals.h
+++ b/lib/globalshortcut/include/globalshortcut/globalshortcut_globals.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #pragma once
 

--- a/lib/globalshortcut/include/globalshortcut/hotkeymanager.h
+++ b/lib/globalshortcut/include/globalshortcut/hotkeymanager.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #pragma once
 #include <QObject>

--- a/lib/globalshortcut/src/hotkeymanager.cpp
+++ b/lib/globalshortcut/src/hotkeymanager.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #include "globalshortcut/hotkeymanager.h"
 #if defined __linux__

--- a/lib/globalshortcut/src/hotkeymanager_x11.cpp
+++ b/lib/globalshortcut/src/hotkeymanager_x11.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #include <QAbstractEventDispatcher>
 #include <QDebug>

--- a/lib/globalshortcut/src/hotkeymanager_x11.h
+++ b/lib/globalshortcut/src/hotkeymanager_x11.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #pragma once
 #include <QDebug>

--- a/lib/xdg/include/xdg/iconlookup.h
+++ b/lib/xdg/include/xdg/iconlookup.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #pragma once
 #include <QStringList>

--- a/lib/xdg/include/xdg/xdg_globals.h
+++ b/lib/xdg/include/xdg/xdg_globals.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #pragma once
 

--- a/lib/xdg/src/iconlookup.cpp
+++ b/lib/xdg/src/iconlookup.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #include <QDebug>
 #include <QDir>

--- a/lib/xdg/src/themefileparser.cpp
+++ b/lib/xdg/src/themefileparser.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #include "themefileparser.h"
 

--- a/lib/xdg/src/themefileparser.h
+++ b/lib/xdg/src/themefileparser.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #pragma once
 #include <QStringList>

--- a/src/app/extension.cpp
+++ b/src/app/extension.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #include <set>
 #include "albert/extension.h"

--- a/src/app/extensionmanager.cpp
+++ b/src/app/extensionmanager.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #include <QApplication>
 #include <QDebug>

--- a/src/app/extensionmanager.h
+++ b/src/app/extensionmanager.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #pragma once
 #include <QObject>

--- a/src/app/frontendmanager.cpp
+++ b/src/app/frontendmanager.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #include <QApplication>
 #include <QDebug>

--- a/src/app/frontendmanager.h
+++ b/src/app/frontendmanager.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #pragma once
 #include <QObject>

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #include <QApplication>
 #include <QCommandLineParser>

--- a/src/app/matchcompare.cpp
+++ b/src/app/matchcompare.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #include "albert/item.h"
 #include "matchcompare.h"

--- a/src/app/matchcompare.h
+++ b/src/app/matchcompare.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #pragma once
 #include <memory>

--- a/src/app/pluginspec.cpp
+++ b/src/app/pluginspec.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #include <QDebug>
 #include <QJsonArray>

--- a/src/app/pluginspec.h
+++ b/src/app/pluginspec.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #pragma once
 #include <QObject>

--- a/src/app/query.cpp
+++ b/src/app/query.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #include <QDebug>
 #include "albert/item.h"

--- a/src/app/queryexecution.cpp
+++ b/src/app/queryexecution.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #include <QDebug>
 #include <QString>

--- a/src/app/queryexecution.h
+++ b/src/app/queryexecution.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #pragma once
 #include <QAbstractListModel>

--- a/src/app/querymanager.cpp
+++ b/src/app/querymanager.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #include <QApplication>
 #include <QDebug>

--- a/src/app/querymanager.h
+++ b/src/app/querymanager.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #pragma once
 #include <QObject>

--- a/src/app/settingswidget/grabkeybutton.cpp
+++ b/src/app/settingswidget/grabkeybutton.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #include "grabkeybutton.h"
 

--- a/src/app/settingswidget/grabkeybutton.h
+++ b/src/app/settingswidget/grabkeybutton.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #pragma once
 #include <QPushButton>

--- a/src/app/settingswidget/loadermodel.cpp
+++ b/src/app/settingswidget/loadermodel.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #include <QIcon>
 #include "loadermodel.h"

--- a/src/app/settingswidget/loadermodel.h
+++ b/src/app/settingswidget/loadermodel.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #pragma once
 #include <QAbstractListModel>

--- a/src/app/settingswidget/settingswidget.cpp
+++ b/src/app/settingswidget/settingswidget.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #include <QApplication>
 #include <QCheckBox>

--- a/src/app/settingswidget/settingswidget.h
+++ b/src/app/settingswidget/settingswidget.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #pragma once
 #include "ui_settingswidget.h"

--- a/src/app/settingswidget/statswidget.cpp
+++ b/src/app/settingswidget/statswidget.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #include "statswidget.h"
 #include <QSqlQuery>

--- a/src/app/settingswidget/statswidget.h
+++ b/src/app/settingswidget/statswidget.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #pragma once
 #include <QtCharts>

--- a/src/app/telemetry.cpp
+++ b/src/app/telemetry.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #include <QApplication>
 #include <QDateTime>

--- a/src/app/telemetry.h
+++ b/src/app/telemetry.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #pragma once
 #include <QJsonObject>

--- a/src/app/trayicon.cpp
+++ b/src/app/trayicon.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #include <QApplication>
 #include <QSettings>

--- a/src/app/trayicon.h
+++ b/src/app/trayicon.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #pragma once
 #include <QObject>

--- a/src/lib/fuzzysearch.cpp
+++ b/src/lib/fuzzysearch.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #include <QRegularExpression>
 #include "fuzzysearch.h"

--- a/src/lib/fuzzysearch.h
+++ b/src/lib/fuzzysearch.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #pragma once
 #include <QString>

--- a/src/lib/history.cpp
+++ b/src/lib/history.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #include <QStringList>
 #include <QVariant>

--- a/src/lib/offlineindex.cpp
+++ b/src/lib/offlineindex.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #include "albert/util/offlineindex.h"
 #include "albert/indexable.h"

--- a/src/lib/plugin.cpp
+++ b/src/lib/plugin.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #include <QStandardPaths>
 #include <QCoreApplication>

--- a/src/lib/prefixsearch.cpp
+++ b/src/lib/prefixsearch.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #include <QRegularExpression>
 #include <algorithm>

--- a/src/lib/prefixsearch.h
+++ b/src/lib/prefixsearch.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #pragma once
 #include <map>

--- a/src/lib/searchbase.cpp
+++ b/src/lib/searchbase.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #include <QRegularExpression>
 #include <QStringList>

--- a/src/lib/searchbase.h
+++ b/src/lib/searchbase.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #pragma once
 #include <QString>

--- a/src/lib/shutil.cpp
+++ b/src/lib/shutil.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2018 Manuel Schneider
+// Copyright (C) 2014-2019 Manuel Schneider
 
 #include "shutil.h"
 #include <QDebug>


### PR DESCRIPTION
License info was removed from individual file comments in 18018c8f7b7dbbc366420c24ba1209bbda1f5267, but no license file was added in their place.

This adds the short GPL text back as its own file to satisfy #765 and avoid any confusion.