### PR TITLE
Termite support

### DIFF
--- a/src/app/settingswidget/settingswidget.cpp
+++ b/src/app/settingswidget/settingswidget.cpp
@@ -167,6 +167,7 @@ Core::SettingsWidget::SettingsWidget(ExtensionManager *extensionManager,
         {"Cool Retro Term", "cool-retro-term -e"},
         {"RoxTerm", "roxterm -x"},
         {"Terminator", "terminator -x"},
+        {"Termite", "termite -e"},
         {"UXTerm", "uxterm -e"},
         {"XTerm", "xterm -e"},
         {"urxvt", "urxvt -e"}


### PR DESCRIPTION
Adds [Termite](https://github.com/thestinger/termite) to the default list of external terminals.