### PR TITLE
Prepend terminalCommand only once

### DIFF
--- a/include/albert/util/standardactions.h
+++ b/include/albert/util/standardactions.h
@@ -100,7 +100,9 @@ public:
 
 private:
     bool shell_;
+    bool prepended_ = false;
     CloseBehavior behavior_;
+    void prependTerminalCommand();
 };
 
 

--- a/src/lib/standardactions.cpp
+++ b/src/lib/standardactions.cpp
@@ -92,9 +92,9 @@ Core::TermAction::TermAction(const QString &text, const QStringList &commandline
 
 }
 
-void Core::TermAction::activate()
+void Core::TermAction::prependTerminalCommand()
 {
-    if (commandline_.isEmpty())
+    if (prepended_)
         return;
 
     if (shell_){
@@ -120,6 +120,16 @@ void Core::TermAction::activate()
     } else {
         commandline_ = Core::ShUtil::split(terminalCommand) + commandline_;
     }
+
+    prepended_ = true;
+}
+
+void Core::TermAction::activate()
+{
+    if (commandline_.isEmpty())
+        return;
+
+    TermAction::prependTerminalCommand();
 
     ProcAction::activate();
 }


### PR DESCRIPTION
The terminalCommand got prepended on every activation of the file. So
for the nth activation, n terminals have spawned, all nested and the
last one acutally executed the command.

Wrapping the executing with a simple boolean guard prevents the nesting.

Fixes #789