### PR TITLE
Fix crashes on Wayland by not loading the HotkeyManager

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -326,15 +326,20 @@ int main(int argc, char **argv) {
         frontendManager = new FrontendManager(pluginDirs);
         extensionManager = new ExtensionManager(pluginDirs);
         extensionManager->reloadExtensions();
-        hotkeyManager = new HotkeyManager;
-        if ( parser.isSet("hotkey") ) {
-            QString hotkey = parser.value("hotkey");
-            if ( !hotkeyManager->registerHotkey(hotkey) )
-                qFatal("Failed to set hotkey to %s.", hotkey.toLocal8Bit().constData());
-        } else if ( settings.contains("hotkey") ) {
-            QString hotkey = settings.value("hotkey").toString();
-            if ( !hotkeyManager->registerHotkey(hotkey) )
-                qFatal("Failed to set hotkey to %s.", hotkey.toLocal8Bit().constData());
+
+        if ( !QGuiApplication::platformName().contains("wayland") )
+            hotkeyManager = new HotkeyManager;
+
+        if ( hotkeyManager ) {
+            if ( parser.isSet("hotkey") ) {
+                QString hotkey = parser.value("hotkey");
+                if ( !hotkeyManager->registerHotkey(hotkey) )
+                    qFatal("Failed to set hotkey to %s.", hotkey.toLocal8Bit().constData());
+            } else if ( settings.contains("hotkey") ) {
+                QString hotkey = settings.value("hotkey").toString();
+                if ( !hotkeyManager->registerHotkey(hotkey) )
+                    qFatal("Failed to set hotkey to %s.", hotkey.toLocal8Bit().constData());
+            }
         }
         queryManager = new QueryManager(extensionManager);
         telemetry  = new Telemetry;

--- a/src/app/settingswidget/settingswidget.cpp
+++ b/src/app/settingswidget/settingswidget.cpp
@@ -354,7 +354,7 @@ void SettingsWidget::keyPressEvent(QKeyEvent *event) {
 
 /** ***************************************************************************/
 void SettingsWidget::closeEvent(QCloseEvent *event) {
-    if (hotkeyManager_->hotkeys().empty()) {
+    if (hotkeyManager_ && hotkeyManager_->hotkeys().empty()) {
         QMessageBox msgBox(QMessageBox::Warning, "Hotkey Missing",
                            "Hotkey is invalid, please set it. Press OK to go "\
                            "back to the settings.",

--- a/src/app/settingswidget/settingswidget.cpp
+++ b/src/app/settingswidget/settingswidget.cpp
@@ -66,13 +66,18 @@ Core::SettingsWidget::SettingsWidget(ExtensionManager *extensionManager,
      */
 
     // HOTKEY
-    QSet<int> hks = hotkeyManager->hotkeys();
-    if (hks.size() < 1)
-        ui.grabKeyButton_hotkey->setText("Press to set hotkey");
-    else
-        ui.grabKeyButton_hotkey->setText(QKeySequence(*hks.begin()).toString()); // OMG
-    connect(ui.grabKeyButton_hotkey, &GrabKeyButton::keyCombinationPressed,
-            this, &SettingsWidget::changeHotkey);
+    if (hotkeyManager) {
+        QSet<int> hks = hotkeyManager->hotkeys();
+        if (hks.size() < 1)
+            ui.grabKeyButton_hotkey->setText("Press to set hotkey");
+        else
+            ui.grabKeyButton_hotkey->setText(QKeySequence(*hks.begin()).toString()); // OMG
+        connect(ui.grabKeyButton_hotkey, &GrabKeyButton::keyCombinationPressed,
+                this, &SettingsWidget::changeHotkey);
+    } else {
+        ui.grabKeyButton_hotkey->setVisible(false);
+        ui.label_hotkey->setVisible(false);
+    }
 
     // TRAY
     ui.checkBox_showTray->setChecked(trayIcon_->isVisible());
@@ -307,6 +312,7 @@ void SettingsWidget::updatePluginInformations(const QModelIndex & current) {
 
 /** ***************************************************************************/
 void SettingsWidget::changeHotkey(int newhk) {
+    Q_ASSERT(hotkeyManager_);
     int oldhk = *hotkeyManager_->hotkeys().begin(); //TODO Make cool sharesdpointer design
 
     // Try to set the hotkey


### PR DESCRIPTION
On Wayland, global hotkeys are often handled by the compositor instead. On sway
for instance, a config file is edited to launch specific commands when a hotkey
is entered.

On such compositors, it should be enough to show Albert by configuring the
compositor to launch "albert show" or "albert toggle" a hotkey manager in
Albert itself is redundant.