### PR TITLE
Fix #789.

### DIFF
--- a/include/albert/util/standardactions.h
+++ b/include/albert/util/standardactions.h
@@ -99,9 +99,6 @@ public:
     void activate() override;
 
 private:
-    bool shell_;
-    CloseBehavior behavior_;
-
     // commandline without terminalCommand prepended to it
     QStringList command_;
 };

--- a/include/albert/util/standardactions.h
+++ b/include/albert/util/standardactions.h
@@ -101,6 +101,9 @@ public:
 private:
     bool shell_;
     CloseBehavior behavior_;
+
+    // commandline without terminalCommand prepended to it
+    QStringList command_;
 };
 
 

--- a/src/lib/standardactions.cpp
+++ b/src/lib/standardactions.cpp
@@ -89,14 +89,6 @@ void Core::ProcAction::activate()
 Core::TermAction::TermAction(const QString &text, const QStringList &commandline, const QString &workingDirectory, bool shell, Core::TermAction::CloseBehavior behavior)
     : ProcAction (text, commandline, workingDirectory), shell_(shell), behavior_(behavior)
 {
-
-}
-
-void Core::TermAction::activate()
-{
-    if (commandline_.isEmpty())
-        return;
-
     if (shell_){
 
         // Quote the input commandline since it's nested
@@ -120,6 +112,13 @@ void Core::TermAction::activate()
     } else {
         commandline_ = Core::ShUtil::split(terminalCommand) + commandline_;
     }
+
+}
+
+void Core::TermAction::activate()
+{
+    if (commandline_.isEmpty())
+        return;
 
     ProcAction::activate();
 }

--- a/src/lib/standardactions.cpp
+++ b/src/lib/standardactions.cpp
@@ -105,20 +105,23 @@ Core::TermAction::TermAction(const QString &text, const QStringList &commandline
             throw "Could not retrieve user shell";
 
         // Let standard shell handle flow control (syntax differs in shells, e.g. fish)
-        commandline_ = Core::ShUtil::split(terminalCommand);
         if (behavior_ == CloseBehavior::DoNotClose)
-            commandline_ << "sh" << "-ic" << QString("%1 -ic '%2'; exec %1").arg(pwd->pw_shell, quotedCommandLine.join(' '));
+            command_ << "sh" << "-ic" << QString("%1 -ic '%2'; exec %1").arg(pwd->pw_shell, quotedCommandLine.join(' '));
         else if (behavior_ == CloseBehavior::CloseOnSuccess)
-            commandline_ << "sh" << "-ic" << QString("%1 -ic '%2' && sleep 1 || exec %1").arg(pwd->pw_shell, quotedCommandLine.join(' '));
+            command_ << "sh" << "-ic" << QString("%1 -ic '%2' && sleep 1 || exec %1").arg(pwd->pw_shell, quotedCommandLine.join(' '));
         else  // behavior_ == CloseBehavior::CloseOnExit
-            commandline_ << "sh" << "-ic" << QString("%1 -ic '%2'; sleep 1 ").arg(pwd->pw_shell, quotedCommandLine.join(' '));
+            command_ << "sh" << "-ic" << QString("%1 -ic '%2'; sleep 1 ").arg(pwd->pw_shell, quotedCommandLine.join(' '));
     } else {
-        commandline_ = Core::ShUtil::split(terminalCommand) + commandline_;
+        command_ = commandline_;
     }
 
 }
 
 void Core::TermAction::activate()
 {
+    if (commandline_.isEmpty())
+        return;
+
+    commandline_ = Core::ShUtil::split(terminalCommand) + command_;
     ProcAction::activate();
 }

--- a/src/lib/standardactions.cpp
+++ b/src/lib/standardactions.cpp
@@ -87,12 +87,12 @@ void Core::ProcAction::activate()
 
 /** **************************************************************************/
 Core::TermAction::TermAction(const QString &text, const QStringList &commandline, const QString &workingDirectory, bool shell, Core::TermAction::CloseBehavior behavior)
-    : ProcAction (text, commandline, workingDirectory), shell_(shell), behavior_(behavior)
+    : ProcAction (text, commandline, workingDirectory)
 {
     if (commandline_.isEmpty())
         return;
 
-    if (shell_){
+    if (shell){
 
         // Quote the input commandline since it's nested
         QStringList quotedCommandLine;
@@ -105,9 +105,9 @@ Core::TermAction::TermAction(const QString &text, const QStringList &commandline
             throw "Could not retrieve user shell";
 
         // Let standard shell handle flow control (syntax differs in shells, e.g. fish)
-        if (behavior_ == CloseBehavior::DoNotClose)
+        if (behavior == CloseBehavior::DoNotClose)
             command_ << "sh" << "-ic" << QString("%1 -ic '%2'; exec %1").arg(pwd->pw_shell, quotedCommandLine.join(' '));
-        else if (behavior_ == CloseBehavior::CloseOnSuccess)
+        else if (behavior == CloseBehavior::CloseOnSuccess)
             command_ << "sh" << "-ic" << QString("%1 -ic '%2' && sleep 1 || exec %1").arg(pwd->pw_shell, quotedCommandLine.join(' '));
         else  // behavior_ == CloseBehavior::CloseOnExit
             command_ << "sh" << "-ic" << QString("%1 -ic '%2'; sleep 1 ").arg(pwd->pw_shell, quotedCommandLine.join(' '));

--- a/src/lib/standardactions.cpp
+++ b/src/lib/standardactions.cpp
@@ -89,6 +89,9 @@ void Core::ProcAction::activate()
 Core::TermAction::TermAction(const QString &text, const QStringList &commandline, const QString &workingDirectory, bool shell, Core::TermAction::CloseBehavior behavior)
     : ProcAction (text, commandline, workingDirectory), shell_(shell), behavior_(behavior)
 {
+    if (commandline_.isEmpty())
+        return;
+
     if (shell_){
 
         // Quote the input commandline since it's nested
@@ -117,8 +120,5 @@ Core::TermAction::TermAction(const QString &text, const QStringList &commandline
 
 void Core::TermAction::activate()
 {
-    if (commandline_.isEmpty())
-        return;
-
     ProcAction::activate();
 }


### PR DESCRIPTION
The command to be executed by TermAction was calculated on every
activation. This calculation was not free of sideeffects and prepended
the terminalcommand on every run.
By moving these calculation to the constructor the problem has been
solved.