### PR TITLE
Add Tilix to list of terminals

### DIFF
--- a/src/app/settingswidget/settingswidget.cpp
+++ b/src/app/settingswidget/settingswidget.cpp
@@ -168,6 +168,7 @@ Core::SettingsWidget::SettingsWidget(ExtensionManager *extensionManager,
         {"RoxTerm", "roxterm -x"},
         {"Terminator", "terminator -x"},
         {"Termite", "termite -e"},
+        {"Tilix", "tilix -e"},
         {"UXTerm", "uxterm -e"},
         {"XTerm", "xterm -e"},
         {"urxvt", "urxvt -e"}


### PR DESCRIPTION
[Tilix](https://github.com/gnunn1/tilix) is a [reasonably popular](https://qa.debian.org/popcon.php?package=tilix) terminal emulator. It would be nice to see it added as one of the options.