### PR TITLE
Update installation link in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Albert is a unified and efficient access to your machine. Technically it is a ke
 
 ## Getting started
 
-Check the section [*Installing Albert*](https://albertlauncher.github.io/docs/installing/) in the docs for setup instructions. When you are set up take a look at the section [*Using Albert*](https://albertlauncher.github.io/docs/using/). If you have problems check the [*Troubleshooting*](https://albertlauncher.github.io/docs/faq/) section. If it does not cover your problems seek for [*help*](https://albertlauncher.github.io/help/) in one of the chats. Developers may want to check the [*Extending Albert*](https://albertlauncher.github.io/docs/extending/) section.
+Check the section [*Installing Albert*](https://albertlauncher.github.io/installing/) in the docs for setup instructions. When you are set up take a look at the section [*Using Albert*](https://albertlauncher.github.io/docs/using/). If you have problems check the [*Troubleshooting*](https://albertlauncher.github.io/docs/faq/) section. If it does not cover your problems seek for [*help*](https://albertlauncher.github.io/help/) in one of the chats. Developers may want to check the [*Extending Albert*](https://albertlauncher.github.io/docs/extending/) section.
 
 ## Albert at a glance
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Albert is a unified and efficient access to your machine. Technically it is a ke
 
 ## Getting started
 
-Check the section [*Installing Albert*](https://albertlauncher.github.io/installing/) in the docs for setup instructions. When you are set up take a look at the section [*Using Albert*](https://albertlauncher.github.io/docs/using/). If you have problems check the [*Troubleshooting*](https://albertlauncher.github.io/docs/faq/) section. If it does not cover your problems seek for [*help*](https://albertlauncher.github.io/help/) in one of the chats. Developers may want to check the [*Extending Albert*](https://albertlauncher.github.io/docs/extending/) section.
+Check the section [*Installing Albert*](https://albertlauncher.github.io/installing/) in the docs for setup instructions. When you are set up take a look at the section [*Using Albert*](https://albertlauncher.github.io/using/). If you have problems check the [*Troubleshooting*](https://albertlauncher.github.io/help/#troubleshooting-and-support) section. If it does not cover your problems seek for help in one of the [*chats*](https://albertlauncher.github.io/help/#chats). Developers may want to check the [*Extending Albert*](https://albertlauncher.github.io/extending/) section.
 
 ## Albert at a glance
 
@@ -31,6 +31,6 @@ Check the section [*Installing Albert*](https://albertlauncher.github.io/install
 
 # Support
 
-If you like this software consider [donating](https://albertlauncher.github.io/docs/donation/) a :beer:. :+1:
+If you like this software consider [donating](https://albertlauncher.github.io/donation/) a :beer:. :+1:
 
 Have fun with albert, if you do not, [tell me why](https://telegram.me/albert_launcher_community).

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -374,7 +374,7 @@ int main(int argc, char **argv) {
         docsAction->setIcon(app->style()->standardIcon(QStyle::SP_DialogHelpButton));
         trayIconMenu->addAction(docsAction);
         QObject::connect(docsAction, &QAction::triggered, [](){
-            QDesktopServices::openUrl(QUrl("https://albertlauncher.github.io/docs/"));
+            QDesktopServices::openUrl(QUrl("https://albertlauncher.github.io/"));
         });
 
         trayIconMenu->addSeparator();


### PR DESCRIPTION
The installation link https://albertlauncher.github.io/docs/installing/ does not work.  This changes it to https://albertlauncher.github.io/installing/ so users following instructions on the README can get to the installation details.