### PR TITLE
Enable High DPI scaling no matter what

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -147,11 +147,7 @@ int main(int argc, char **argv) {
 
         INFO << "Initializing application";
 #if QT_VERSION >= 0x050600  // TODO: Remove when 18.04 is released
-        if (!qEnvironmentVariableIsSet("QT_DEVICE_PIXEL_RATIO")
-                && !qEnvironmentVariableIsSet("QT_AUTO_SCREEN_SCALE_FACTOR")
-                && !qEnvironmentVariableIsSet("QT_SCALE_FACTOR")
-                && !qEnvironmentVariableIsSet("QT_SCREEN_SCALE_FACTORS"))
-            QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+        QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
         QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 #endif
         app = make_unique<QApplication>(argc, argv);


### PR DESCRIPTION
 My reading of the Qt5 documents on this setting is that this should
 just always be enabled once there's confirmation that HighDpi is
 well supported (it seems to work well on my machine and it avoids
 issues related to using scaling via environment variables, as that
 will get inherited by programs spawned by Albert)

I'm running this locally without issue. I am not 100% sure if this is the right thing to do here, but it sure feels like it!