### PR TITLE
Add Console as a Terminal Provider

### DIFF
--- a/src/terminalprovider.cpp
+++ b/src/terminalprovider.cpp
@@ -66,6 +66,7 @@ struct ExecutableTerminal : public Terminal
 static const vector<ExecutableTerminal> exec_terminals
 {
         {"Alacritty", {"alacritty", "-e"}},
+        {"Console", {"kgx", "-e"}},
         {"Cool Retro Term", {"cool-retro-term", "-e"}},
         {"Deepin Terminal", {"deepin-terminal", "-x"}},
         {"Elementary Terminal", {"io.elementary.terminal", "-x"}},


### PR DESCRIPTION
This PR adds support for [Console](https://gitlab.gnome.org/GNOME/console), the default terminal emulator for GNOME Shell.

Console is a simpler terminal emulator than GNOME Terminal, targeting average users rather than developers/administrators.