### PR TITLE
Support st terminal

### DIFF
--- a/src/terminalprovider.cpp
+++ b/src/terminalprovider.cpp
@@ -65,6 +65,7 @@ struct ExecutableTerminal : public Terminal
 
 static const vector<ExecutableTerminal> exec_terminals
 {
+        {"St", {"st", "-e"}},
         {"Alacritty", {"alacritty", "-e"}},
         {"Console", {"kgx", "-e"}},
         {"Cool Retro Term", {"cool-retro-term", "-e"}},


### PR DESCRIPTION
I've also added it to the top of list, as st is very minimalist and quick-starting terminal, so suitable for such use case.