### PR TITLE
Added reloadTheme to frontend

### DIFF
--- a/include/albert/albert.h
+++ b/include/albert/albert.h
@@ -21,4 +21,6 @@ ALBERT_EXPORT void quit();
 ALBERT_EXPORT void runTerminal(const QString &script = {}, const QString &working_dir = {}, bool close_on_exit = false);
 
 ALBERT_EXPORT void sendTrayNotification(const QString &title, const QString &message, int msTimeoutHint);
+
+ALBERT_EXPORT void reloadTheme ();
 }

--- a/include/albert/extensions/frontend.h
+++ b/include/albert/extensions/frontend.h
@@ -56,6 +56,7 @@ public:
     virtual void setInput(const QString&) = 0;
     virtual QWidget *createFrontendConfigWidget() = 0;
     void setEngine(QueryEngine*);
+    virtual void reloadTheme () = 0;
 protected:
     std::shared_ptr<Query> query(const QString &query) const;
 private:

--- a/src/albert.cpp
+++ b/src/albert.cpp
@@ -77,6 +77,11 @@ void albert::sendTrayNotification(const QString &title, const QString &message, 
     app->tray_icon.showMessage(title, message, QSystemTrayIcon::NoIcon, ms);
 }
 
+void albert::reloadTheme()
+{
+    app->plugin_provider.frontend()->reloadTheme();
+}
+
 
 static void messageHandler(QtMsgType type, const QMessageLogContext &context, const QString &message)
 {

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -36,7 +36,11 @@ static std::map<QString, std::function<QString(const QString&)>> actions =
         {"quit", [](const QString&){
             albert::quit();
             return "Triggered quit.";
-        }}
+        }},
+        {"reloadtheme", [](const QString&){
+            albert::reloadTheme ();
+            return "Reload happened.";
+        }},
 };
 
 


### PR DESCRIPTION
Added an option to reload the current theme's qss file.

Run
```albert reloadtheme```
to re-parse the qss file.

Useful for pywal users that auto-generate so we can generate the qss file ourselves. Needs of the PR I've just opened on the plugins project.