### PR TITLE
Revert "Use wayland workaround from #958"

### DIFF
--- a/dist/albert.desktop
+++ b/dist/albert.desktop
@@ -2,7 +2,7 @@
 [Desktop Entry]
 Categories=Utility;
 Comment=A desktop agnostic launcher
-Exec=/usr/bin/env QT_QPA_PLATFORM=xcb albert
+Exec=albert
 GenericName=Launcher
 Icon=albert
 Name=Albert


### PR DESCRIPTION
As discussed in #1193, running `QT_QPA_PLATFORM=xcb` on a launcher is not a sustainable solution.

As [90f2ccade6b8976aa0d5b080eeded9bcc7eb35d1](https://github.com/albertlauncher/plugins/commit/90f2ccade6b8976aa0d5b080eeded9bcc7eb35d1) gets reverted, the behavior of the launcher changed, resulting unreliable launch behavior.

While running without it on wayland doesn't seem to crash anymore, I hope this workaround can be reverted.