### PR TITLE
fix: change config path from `~/.config/albert.conf` back to `~/.config/albert/albert.conf`, fixes #1191

### DIFF
--- a/src/albert.cpp
+++ b/src/albert.cpp
@@ -182,7 +182,7 @@ QNetworkAccessManager *albert::networkManager()
 { return &app->network_manager; }
 
 std::unique_ptr<QSettings> albert::settings()
-{ return make_unique<QSettings>(qApp->applicationName()); }
+{ return make_unique<QSettings>(qApp->applicationName(), qApp->applicationName()); }
 
 std::unique_ptr<QSettings> albert::state()
 { return make_unique<QSettings>(QString("%1/%2").arg(cacheLocation(), "albert.state"), QSettings::IniFormat); }


### PR DESCRIPTION
[fix: change config path back to `~/.config/albert/albert.conf`, fixes… by stevenxxiu · Pull Request #1195 · albertlauncher/albert](https://github.com/albertlauncher/albert/pull/1195) got closed due to the branch rename. This does the same thing.