### PR TITLE
Fix typo in sort preference label

### DIFF
--- a/src/settings/querywidget/querywidget.ui
+++ b/src/settings/querywidget/querywidget.ui
@@ -77,7 +77,7 @@
      <item row="0" column="0">
       <widget class="QLabel" name="label_decay">
        <property name="text">
-        <string>Sort perference</string>
+        <string>Sort preference</string>
        </property>
        <property name="buddy">
         <cstring>slider_decay</cstring>


### PR DESCRIPTION
Fixes a small typo in the Albert Settings > Query > Sort preference label.