### PR TITLE
fix(GeneratorQueryHandler): replay fetchMore requests made while active

### DIFF
--- a/src/query/generatorqueryhandler.cpp
+++ b/src/query/generatorqueryhandler.cpp
@@ -19,6 +19,7 @@ class GeneratorQueryHandlerExecution final : public QueryExecution
     ItemGenerator generator;  // mutexed
     optional<ItemGenerator::iterator> iterator;  // mutexed
     bool active;
+    bool fetch_more_pending;
     // items(), begin and operator++ are potentially long blocking operations.
     // it had to be mutexed because canFetchMore may check the iterator in the main thread.
     // awaiting the lock however blocks the main thread potentially long.
@@ -35,6 +36,7 @@ public:
         , handler(h)
         , iterator(nullopt)
         , active(true)
+        , fetch_more_pending(false)
         , at_end(false)
     {
         connect(&watcher, &QFutureWatcher<void>::finished,
@@ -78,7 +80,16 @@ public:
 
     void fetchMore() override
     {
-        if (!isActive() && canFetchMore())
+        if (!canFetchMore())
+            return;
+
+        if (isActive())
+        {
+            // Model updates can synchronously trigger fetchMore while this execution is still active.
+            // Queue the request and replay it right after this batch finished.
+            fetch_more_pending = true;
+        }
+        else
         {
             emit activeChanged(active = true);
             watcher.setFuture(QtConcurrent::run([this] -> vector<shared_ptr<Item>>
@@ -114,6 +125,13 @@ public:
             }
 
         emit activeChanged(active = false);
+
+        if (fetch_more_pending)
+        {
+            fetch_more_pending = false;
+            if (!isActive())
+                fetchMore();
+        }
     }
 };
 


### PR DESCRIPTION
Hello, I ended up digging in a bit and finding a fix (and test case) for the issue I reported earlier with the Python plugin. With this change my example plugin works as expected.

To be totally transparent - I did use AI/LLM tools in this PR, but I have read and understood everything I'm submitting here.