### PR TITLE
fix(xdg): configure qt xcb via environmnet

### DIFF
--- a/dist/xdg/albert.desktop
+++ b/dist/xdg/albert.desktop
@@ -2,7 +2,7 @@
 [Desktop Entry]
 Categories=Utility;
 Comment=A desktop agnostic launcher
-Exec=albert --platform xcb %u
+Exec=env QT_QPA_PLATFORM=xcb albert %u
 GenericName=Launcher
 Icon=albert
 Name=Albert
@@ -12,4 +12,3 @@ Version=1.0
 MimeType=x-scheme-handler/albert
 # Give desktop environments time to init. Otherwise QGnomePlatform does not correctly pick up the palette.
 X-GNOME-Autostart-Delay=3
-


### PR DESCRIPTION
This configures the qt "xcb" plugin via environment rather than via command line option. When restarting albert via the applet menu dialog, it restarts without using the specified "--platform xcb" option.

Configuring it in the environment allows persistent configuration across restarts.