### PR TITLE
feat: vicinae-hotkey-v1 global shortcut backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -356,6 +356,29 @@ elseif(UNIX)
             PRIVATE -DMULTIARCH_TUPLE="${CMAKE_LIBRARY_ARCHITECTURE}"
         )
     endif()
+
+    find_package(Qt6 6.5 QUIET COMPONENTS WaylandClient)
+    find_package(PkgConfig QUIET)
+    if (PKG_CONFIG_FOUND)
+        pkg_check_modules(xkbcommon QUIET IMPORTED_TARGET xkbcommon)
+    endif()
+
+    if (Qt6WaylandClient_FOUND AND TARGET PkgConfig::xkbcommon)
+        enable_language(C)
+        qt6_generate_wayland_protocol_client_sources(${TARGET_LIB}
+            FILES "${PROJECT_SOURCE_DIR}/src/platform/xdg/vicinae-hotkey-v1.xml"
+        )
+        target_sources(${TARGET_LIB} PRIVATE
+            src/platform/xdg/waylandhotkey.cpp
+            src/platform/xdg/waylandhotkey.h
+        )
+        target_link_libraries(${TARGET_LIB} PRIVATE Qt6::WaylandClient PkgConfig::xkbcommon)
+        target_compile_definitions(${TARGET_LIB} PRIVATE HAVE_WAYLAND_HOTKEY)
+        message(STATUS "Building with Wayland global hotkey support (vicinae-hotkey-v1)")
+    else()
+        message(STATUS "Building without Wayland global hotkey support "
+                       "(requires Qt6WaylandClient >= 6.5 and xkbcommon)")
+    endif()
 endif()
 
 target_compile_features(${TARGET_LIB} PUBLIC cxx_std_23)

--- a/src/app/hotkey.cpp
+++ b/src/app/hotkey.cpp
@@ -2,6 +2,9 @@
 
 #include "hotkey.h"
 #include <QHotkey>
+#ifdef HAVE_WAYLAND_HOTKEY
+#include "waylandhotkey.h"
+#endif
 using enum QKeySequence::SequenceFormat;
 using namespace Qt::StringLiterals;
 using namespace std;
@@ -19,31 +22,62 @@ static inline QKeyCombination toKeyCombination(const QString &s)
 class Hotkey::Private
 {
 public:
-    QHotkey hotkey;
+    QKeyCombination key_combination;
+    unique_ptr<QHotkey> hotkey;
+#ifdef HAVE_WAYLAND_HOTKEY
+    unique_ptr<WaylandHotkey> wayland_hotkey;
+#endif
 };
 
 Hotkey::Hotkey(QKeyCombination kc) :
     d(make_unique<Private>())
 {
-    d->hotkey.setShortcut(kc);
+    d->key_combination = kc;
 
-    if (!d->hotkey.setRegistered(true))
+#ifdef HAVE_WAYLAND_HOTKEY
+    if (WaylandHotkey::isPlatformSupported())
+    {
+        if (auto hk = WaylandHotkey::grab(kc))
+        {
+            d->wayland_hotkey = ::move(hk.value());
+            connect(d->wayland_hotkey.get(), &WaylandHotkey::activated, this, &Hotkey::activated);
+            connect(d->wayland_hotkey.get(), &WaylandHotkey::revoked, this, &Hotkey::revoked);
+            return;
+        }
+        else
+            throw runtime_error(u"Failed to register hotkey '%1': %2"_s
+                                    .arg(toString(kc, NativeText), hk.error())
+                                    .toStdString());
+    }
+#endif
+
+    d->hotkey = make_unique<QHotkey>();
+    d->hotkey->setShortcut(kc);
+
+    if (!d->hotkey->setRegistered(true))
         throw runtime_error(u"Failed to register hotkey '%1'"_s
-                                .arg(QKeySequence(kc).toString(QKeySequence::NativeText))
+                                .arg(toString(kc, NativeText))
                                 .toStdString());
 
-    connect(&d->hotkey, &QHotkey::activated, this, &Hotkey::activated);
+    connect(d->hotkey.get(), &QHotkey::activated, this, &Hotkey::activated);
 }
 
 Hotkey::~Hotkey() {}
 
-QKeyCombination Hotkey::keyCombination() const { return d->hotkey.shortcut()[0]; }
+QKeyCombination Hotkey::keyCombination() const { return d->key_combination; }
 
 QString Hotkey::nativeString() const { return toString(keyCombination(), NativeText); }
 
 QString Hotkey::portableString() const { return toString(keyCombination(), PortableText); }
 
-bool Hotkey::isPlatformSupported() { return QHotkey::isPlatformSupported(); }
+bool Hotkey::isPlatformSupported()
+{
+#ifdef HAVE_WAYLAND_HOTKEY
+    if (WaylandHotkey::isPlatformSupported())
+        return true;
+#endif
+    return QHotkey::isPlatformSupported();
+}
 
 expected<unique_ptr<Hotkey>, QString> Hotkey::grab(QKeyCombination kc)
 {

--- a/src/app/hotkey.h
+++ b/src/app/hotkey.h
@@ -29,4 +29,5 @@ private:
 
 signals:
     void activated();
+    void revoked(const QString &message);
 };

--- a/src/app/hotkeymanager.cpp
+++ b/src/app/hotkeymanager.cpp
@@ -30,6 +30,8 @@ HotkeyManager::HotkeyManager(const QSettings &settings)
         {
             hotkey_ = ::move(hk.value());
             connect(hotkey_.get(), &Hotkey::activated, this, &HotkeyManager::activated);
+            connect(hotkey_.get(), &Hotkey::revoked,
+                    this, &HotkeyManager::onRevoked, Qt::QueuedConnection);
             INFO << "Hotkey set to" << s_hk;
         }
         else
@@ -55,6 +57,8 @@ void HotkeyManager::setHotkey(unique_ptr<Hotkey> hotkey)
     {
         app().settings()->setValue(CFG_HOTKEY, hotkey_->portableString());
         connect(hotkey_.get(), &Hotkey::activated, this, &HotkeyManager::activated);
+        connect(hotkey_.get(), &Hotkey::revoked,
+                this, &HotkeyManager::onRevoked, Qt::QueuedConnection);
         INFO << "Hotkey set to" << hotkey_->nativeString();
     }
     else
@@ -62,4 +66,20 @@ void HotkeyManager::setHotkey(unique_ptr<Hotkey> hotkey)
         app().settings()->setValue(CFG_HOTKEY, QString());
         INFO << "Hotkey disabled";
     }
+}
+
+void HotkeyManager::onRevoked(const QString &message)
+{
+    if (!hotkey_)
+        return;
+
+    const auto native_string = hotkey_->nativeString();
+    hotkey_.reset();
+
+    auto *t = QT_TR_NOOP("The hotkey '%1' has been revoked by the system.");
+    WARN << QString::fromUtf8(t).arg(native_string) << message;
+    warning(message.isEmpty()
+                ? tr(t).arg(native_string)
+                : QString("%1\n\n%2").arg(tr(t).arg(native_string), message));
+    app().showSettings();
 }

--- a/src/app/hotkeymanager.h
+++ b/src/app/hotkeymanager.h
@@ -17,6 +17,8 @@ public:
     void setHotkey(std::unique_ptr<Hotkey> hotkey);
 
 private:
+    void onRevoked(const QString &message);
+
     std::unique_ptr<Hotkey> hotkey_;
 
 signals:

--- a/src/platform/xdg/vicinae-hotkey-v1.xml
+++ b/src/platform/xdg/vicinae-hotkey-v1.xml
@@ -1,0 +1,305 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="vicinae_hotkey_v1">
+  <copyright>
+    Copyright © 2026 Aurelien Brabant
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="client-managed global hotkeys">
+    This protocol lets a client choose, and freely reconfigure, its own
+    global hotkeys: it requests a specific key combination and the compositor
+    accepts it or rejects it with a reason. The compositor remains the eventual
+    arbiter (it may deny a request, revoke a binding at any time, or apply
+    whatever policy it likes), but within that the application manages its own
+    bindings, including changing them at runtime, with no out-of-band user
+    configuration and no persisted compositor state.
+
+    A hotkey is a key combination that fires regardless of which surface holds
+    keyboard focus. This is unrelated to keyboard-shortcuts-inhibit, which lets a
+    focused client suppress the compositor's own shortcuts.
+
+    Whether a combination is exclusive is compositor policy. A compositor MAY
+    treat combinations as exclusive and reject a clashing request with
+    "already_bound", or MAY grant the same combination to more than one binding
+    (each bound hotkey then receives the events), as some platforms do. Clients
+    must cope with either.
+
+    It is intentionally a thin mechanism. It does NOT define which combinations
+    are acceptable: that is policy and belongs to the compositor, expressed
+    through the accept/deny channel. It does NOT persist hotkeys: a binding lives
+    only as long as its vicinae_hotkey_v1 object and the client connection; there is
+    no configure or storage step, a binding never outlives the client that created
+    it, and reconfiguring is simply destroying a hotkey and binding the new
+    combination.
+
+    Warning! The protocol described in this file is currently in the testing
+    phase. Backward incompatible changes may be added together with the
+    corresponding interface version bump. Backward compatible changes are added
+    by bumping the interface version.
+
+    Security considerations:
+
+    A global hotkey lets an unfocused client observe that a specific key
+    combination was pressed. Compositors are the security boundary and SHOULD
+    apply policy when deciding whether to accept a request. In particular,
+    implementations SHOULD reject combinations that do not include at least one
+    non-latching modifier among Ctrl, Alt or Super, unless the trigger is a
+    function key, because unmodified (and Shift-only) keys carry ordinary text
+    entry and grabbing them turns this protocol into a keylogger.
+
+    The protocol's one hard guarantee is containment: a compositor MUST NOT
+    deliver events for a combination the client did not successfully bind, and
+    never forwards the raw key stream, so a client learns nothing about input it
+    did not explicitly, and successfully, bind. Beyond that, a compositor MAY
+    apply any further policy it sees fit (for example prompting the user,
+    restricting which clients may bind, or limiting how many bindings a client may
+    hold) and MAY revoke a binding at any time via the "revoked" event, including
+    under user control.
+
+    These are recommendations, not wire requirements: a combination the
+    compositor disallows is simply reported through the "denied" event with the
+    "not_permitted" reason, so applications can rely on a uniform rejection path
+    regardless of each compositor's policy.
+  </description>
+
+  <interface name="vicinae_hotkey_manager_v1" version="1">
+    <description summary="global hotkey factory">
+      This interface is the entry point of the protocol. It is used to request
+      global hotkeys.
+    </description>
+
+    <enum name="modifiers" bitfield="true">
+      <description summary="modifier keys required by a hotkey">
+        A bitmask of the modifiers that must be held for the hotkey to fire.
+
+        These are fixed, keymap-independent semantic bits naming the standard
+        modifiers, suitable for expressing a binding, unlike wl_keyboard.modifiers,
+        which carries opaque, keymap-derived masks for runtime state. A compositor
+        matches each bit against the corresponding modifier in its keyboard state
+        as the keymap defines it; for the xkb_v1 keymap format that is shift ->
+        XKB_MOD_NAME_SHIFT, ctrl -> XKB_MOD_NAME_CTRL, alt -> XKB_MOD_NAME_ALT
+        ("Mod1"), super -> XKB_MOD_NAME_LOGO ("Mod4").
+
+        Lock modifiers (Caps Lock, Num Lock) are never part of a binding and are
+        ignored when matching.
+      </description>
+      <entry name="shift" value="1" summary="the Shift modifier"/>
+      <entry name="ctrl" value="2" summary="the Control modifier"/>
+      <entry name="alt" value="4" summary="the Alt modifier"/>
+      <entry name="super" value="8" summary="the Super/Logo modifier"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the manager">
+        Destroy the manager object. Hotkey objects created through this manager
+        are unaffected and remain valid; their bindings persist until they are
+        themselves destroyed or the client disconnects.
+      </description>
+    </request>
+
+    <request name="bind">
+      <description summary="request a global hotkey">
+        Request that the given key combination be bound as a global hotkey.
+
+        The keysym identifies the trigger key using the keysym numbering shared
+        with the keymap delivered over wl_keyboard (for the xkb_v1 keymap format,
+        an XKB_KEY_* value), taken in its unshifted form (XKB_KEY_b not XKB_KEY_B). A compositor SHOULD match
+        it against any of the user's layout groups, so a binding keeps firing after
+        the user switches layout group. This is one deliberately specified rule,
+        not a universal one: other platforms differ (macOS matches a physical
+        keycode, X11 re-grabs per layout, Windows tracks the active layout's key),
+        and no rule serves a layout that never produces the keysym; the single
+        documented rule is chosen for predictability across compositors.
+
+        The request creates an vicinae_hotkey_v1 object immediately, but the binding
+        is not active yet. The compositor replies asynchronously with either the
+        "bound" event (the hotkey is now active) or the "denied" event (the
+        request was rejected, with a reason).
+
+        seat is the wl_seat whose keyboard should trigger the hotkey, or null to
+        request it on all of the client's seats. Most clients pass null; seat is
+        provided for completeness on multi-seat systems.
+
+        app_id identifies the requesting application, for use in the compositor's
+        policy and any user-facing audit UI. Where the application has a desktop
+        entry, app_id SHOULD be its desktop file ID as defined by the
+        freedesktop.org Desktop Entry specification, that is the .desktop file
+        name with the .desktop suffix removed (for example "org.example.Launcher"),
+        matching the convention used by xdg_toplevel.set_app_id so a compositor
+        can correlate the two. It is advisory and may be spoofed; a compositor
+        that needs a trustworthy identity SHOULD obtain it through the
+        security-context mechanism rather than relying on this string.
+
+        description is a human-readable, localized description of what the hotkey
+		  does (e.g. "Toggle the launcher"), for display in compositor UI or even in this protocol error messages.
+      </description>
+      <arg name="id" type="new_id" interface="vicinae_hotkey_v1"
+           summary="the new hotkey object"/>
+      <arg name="keysym" type="uint" summary="keysym of the trigger key (see description)"/>
+      <arg name="modifiers" type="uint" enum="modifiers"
+           summary="bitmask of required modifiers"/>
+      <arg name="seat" type="object" interface="wl_seat" allow-null="true"
+           summary="target seat, or null for all of the client's seats"/>
+      <arg name="app_id" type="string"
+           summary="advisory application identifier (SHOULD be the desktop file ID)"/>
+      <arg name="description" type="string"
+           summary="human-readable action description"/>
+    </request>
+  </interface>
+
+  <interface name="vicinae_hotkey_v1" version="1">
+    <description summary="a single global hotkey">
+      Represents one requested global hotkey. Its binding is ephemeral: it is
+      released when this object is destroyed or when the client disconnects, and
+      it is never written to any persistent store.
+
+      After bind, exactly one of "bound" or "denied" is sent. While the hotkey is
+      bound, "pressed" and "released" are sent as the combination is activated.
+      The compositor may send "revoked" at any time after "bound" to indicate the
+      binding is no longer active (for example because the user removed it, or a
+      higher-priority binding took the combination).
+    </description>
+
+    <enum name="deny_reason">
+      <description summary="why a bind request was denied">
+        Carried by the "denied" event. This is a reason code, not a fatal
+        protocol error: the object remains valid and the client should destroy
+        it (or try a different combination).
+      </description>
+      <entry name="already_bound" value="0"
+             summary="already held by another hotkey the compositor treats as exclusive. The compositor is not obligated to give this level of detail and can just give not_permitted as the general 'deny' reason."/>
+      <entry name="not_permitted" value="1"
+             summary="the combination is disallowed by compositor policy"/>
+      <entry name="invalid" value="2"
+             summary="the keysym or combination is not a valid trigger"/>
+    </enum>
+
+    <enum name="revoke_reason">
+      <description summary="why a previously bound hotkey was withdrawn">
+        Carried by the "revoked" event. This is a reason code, not a fatal
+        protocol error: the object remains valid and the client should destroy
+        it.
+
+        The distinction is actionable: on "superseded" the combination may
+        become available again, so a client may reasonably re-request it later;
+        on "removed" the withdrawal is a deliberate user or compositor decision,
+        so a client MUST NOT silently re-request the same combination. A client
+        that receives a value it does not recognise (a future addition) MUST
+        treat it conservatively as "removed" and not auto-rebind.
+      </description>
+      <entry name="removed" value="0"
+             summary="withdrawn by the user or compositor; do not auto-rebind"/>
+      <entry name="superseded" value="1"
+             summary="a higher-priority binding took the combination; it may become available again"/>
+      <entry name="not_permitted" value="2"
+             summary="the combination is no longer allowed by compositor policy"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="release the hotkey">
+        Release the binding and destroy the object. The combination becomes
+        available again immediately. It is valid to destroy the object before
+        receiving "bound" or "denied", which cancels the pending request.
+      </description>
+    </request>
+
+    <event name="bound">
+      <description summary="the hotkey is now active">
+        The requested combination was accepted and is now active. "pressed" and
+        "released" events may follow.
+      </description>
+    </event>
+
+    <event name="denied">
+      <description summary="the request was rejected">
+        The requested combination was not bound. No input events will be sent.
+        The client should destroy this object; it may then create a new request
+        with a different combination.
+
+        message is an optional, advisory, human-readable explanation in the
+        compositor's locale, intended for verbatim display in client UI (for
+        example a "change shortcut" settings screen). It may be empty, and a
+        compositor is never required to provide it. Clients MUST NOT parse it or
+        rely on its contents in any way; all programmatic behavior keys off
+        reason. A client with nowhere to show it simply ignores it.
+      </description>
+      <arg name="reason" type="uint" enum="deny_reason" summary="why it was rejected"/>
+      <arg name="message" type="string"
+           summary="optional human-readable detail for display (may be empty)"/>
+    </event>
+
+    <event name="revoked">
+      <description summary="a previously active hotkey was withdrawn">
+        A binding that was previously "bound" is no longer active. No further
+        input events will be sent for it. The client should destroy this object;
+        it may request the combination again later.
+
+        message is an optional, advisory, human-readable explanation in the
+        compositor's locale, intended for verbatim display in client UI. It may
+        be empty, and a compositor is never required to provide it. Clients MUST
+        NOT parse it or rely on its contents in any way; all programmatic
+        behavior keys off reason. A client with nowhere to show it simply
+        ignores it.
+      </description>
+      <arg name="reason" type="uint" enum="revoke_reason" summary="why it was withdrawn"/>
+      <arg name="message" type="string"
+           summary="optional human-readable detail for display (may be empty)"/>
+    </event>
+
+    <event name="pressed">
+      <description summary="the hotkey combination was pressed">
+        The bound combination was activated.
+
+        This event is sent once per activation. While the combination is held
+        down no further "pressed" events are sent, and a single "released"
+        follows when the trigger key is released: the compositor does not
+        auto-repeat the hotkey.
+
+        serial is a compositor-issued input serial that counts as a recent user
+        interaction, so the client can act on the hotkey even though the
+        triggering key press is not otherwise delivered to it (the compositor
+        consumes it). In particular, a client may pass this serial to
+        xdg_activation_token_v1.set_serial in order to raise or focus a surface in
+        response to the hotkey; a compositor SHOULD honor activation carried by
+        this serial, since the hotkey is itself a deliberate user action. The
+        serial is drawn from the same space as other input event serials.
+
+        time is the event timestamp, with the same millisecond clock as wl_pointer
+        and wl_keyboard input events; it is useful for ordering and for measuring
+        press-to-release duration.
+      </description>
+      <arg name="serial" type="uint" summary="input serial for the activation (e.g. xdg-activation)"/>
+      <arg name="time" type="uint" summary="timestamp in milliseconds"/>
+    </event>
+
+    <event name="released">
+      <description summary="the hotkey combination was released">
+        The trigger key of a previously pressed combination was released. This
+        enables press-and-hold uses (e.g. push-to-talk); clients that only act
+        on activation may ignore it.
+
+        serial and time have the same meaning as in the "pressed" event.
+      </description>
+      <arg name="serial" type="uint" summary="input serial for the activation (e.g. xdg-activation)"/>
+      <arg name="time" type="uint" summary="timestamp in milliseconds"/>
+    </event>
+  </interface>
+</protocol>

--- a/src/platform/xdg/waylandhotkey.cpp
+++ b/src/platform/xdg/waylandhotkey.cpp
@@ -1,0 +1,182 @@
+// Copyright (c) 2026-2026 Aurelien Brabant
+
+#include "qwayland-vicinae-hotkey-v1.h"
+#include "waylandhotkey.h"
+#include <QEventLoop>
+#include <QGuiApplication>
+#include <QKeySequence>
+#include <QPointer>
+#include <QTimer>
+#include <QWaylandClientExtensionTemplate>
+#include <xkbcommon/xkbcommon.h>
+using namespace Qt::StringLiterals;
+using namespace std;
+
+namespace {
+
+static const int bind_reply_timeout_ms = 10000;
+
+class Manager : public QWaylandClientExtensionTemplate<Manager>,
+                public QtWayland::vicinae_hotkey_manager_v1
+{
+public:
+    Manager() : QWaylandClientExtensionTemplate(1) { initialize(); }
+    ~Manager() { if (isInitialized()) destroy(); }
+};
+
+static Manager *manager()
+{
+    static QPointer<Manager> manager = []() -> Manager * {
+        if (!qGuiApp || QGuiApplication::platformName() != u"wayland"_s)
+            return nullptr;
+        auto *m = new Manager;
+        m->setParent(qGuiApp);
+        return m;
+    }();
+    return manager;
+}
+
+static uint32_t toNativeModifiers(Qt::KeyboardModifiers modifiers)
+{
+    using M = QtWayland::vicinae_hotkey_manager_v1;
+    uint32_t native_modifiers = 0;
+    if (modifiers & Qt::ShiftModifier)
+        native_modifiers |= M::modifiers_shift;
+    if (modifiers & Qt::ControlModifier)
+        native_modifiers |= M::modifiers_ctrl;
+    if (modifiers & Qt::AltModifier)
+        native_modifiers |= M::modifiers_alt;
+    if (modifiers & Qt::MetaModifier)
+        native_modifiers |= M::modifiers_super;
+    return native_modifiers;
+}
+
+static xkb_keysym_t toKeysym(Qt::Key key)
+{
+    switch (key)
+    {
+    case Qt::Key_Escape: return XKB_KEY_Escape;
+    case Qt::Key_PageUp: return XKB_KEY_Prior;
+    case Qt::Key_PageDown: return XKB_KEY_Next;
+    case Qt::Key_Insert: return XKB_KEY_Insert;
+    case Qt::Key_Delete: return XKB_KEY_Delete;
+    case Qt::Key_Print: return XKB_KEY_Print;
+    case Qt::Key_MediaLast:
+    case Qt::Key_MediaPrevious: return XKB_KEY_XF86AudioPrev;
+    case Qt::Key_MediaNext: return XKB_KEY_XF86AudioNext;
+    case Qt::Key_MediaPause:
+    case Qt::Key_MediaPlay:
+    case Qt::Key_MediaTogglePlayPause: return XKB_KEY_XF86AudioPlay;
+    case Qt::Key_MediaRecord: return XKB_KEY_XF86AudioRecord;
+    case Qt::Key_MediaStop: return XKB_KEY_XF86AudioStop;
+    default: break;
+    }
+
+    const auto string = QKeySequence(key).toString(QKeySequence::PortableText);
+    if (string.isEmpty())
+        return XKB_KEY_NoSymbol;
+    else if (string.size() == 1)
+        return xkb_utf32_to_keysym(string.front().toLower().unicode());
+    else
+        return xkb_keysym_from_name(string.toUtf8().constData(), XKB_KEYSYM_CASE_INSENSITIVE);
+}
+
+}
+
+class WaylandHotkey::Private : public QtWayland::vicinae_hotkey_v1
+{
+public:
+    enum class State { Pending, Bound, Denied, Revoked };
+
+    WaylandHotkey &q;
+    State state = State::Pending;
+    QString denial_message;
+    function<void()> on_settled;
+
+    Private(WaylandHotkey &hotkey, struct ::vicinae_hotkey_v1 *object) :
+        QtWayland::vicinae_hotkey_v1(object),
+        q(hotkey)
+    {}
+
+    ~Private() { destroy(); }
+
+protected:
+
+    void vicinae_hotkey_v1_bound() override
+    {
+        state = State::Bound;
+        if (on_settled)
+            on_settled();
+    }
+
+    void vicinae_hotkey_v1_denied(uint32_t reason, const QString &message) override
+    {
+        state = State::Denied;
+        if (!message.isEmpty())
+            denial_message = message;
+        else if (reason == deny_reason_already_bound)
+            denial_message = u"Already bound by another application."_s;
+        else if (reason == deny_reason_invalid)
+            denial_message = u"Invalid key combination."_s;
+        else
+            denial_message = u"Not permitted by compositor policy."_s;
+        if (on_settled)
+            on_settled();
+    }
+
+    void vicinae_hotkey_v1_revoked(uint32_t, const QString &message) override
+    {
+        state = State::Revoked;
+        emit q.revoked(message);
+    }
+
+    void vicinae_hotkey_v1_pressed(uint32_t, uint32_t) override { emit q.activated(); }
+};
+
+WaylandHotkey::WaylandHotkey() = default;
+
+WaylandHotkey::~WaylandHotkey() = default;
+
+bool WaylandHotkey::isPlatformSupported()
+{
+    const auto *m = manager();
+    return m && m->isActive();
+}
+
+expected<unique_ptr<WaylandHotkey>, QString> WaylandHotkey::grab(QKeyCombination key_combination)
+{
+    auto *m = manager();
+    if (!m || !m->isActive())
+        return unexpected(u"Compositor does not support vicinae-hotkey-v1."_s);
+
+    const auto keysym = toKeysym(key_combination.key());
+    if (keysym == XKB_KEY_NoSymbol)
+        return unexpected(u"Key has no keysym representation."_s);
+
+    unique_ptr<WaylandHotkey> hotkey(new WaylandHotkey);
+    hotkey->d = make_unique<Private>(
+        *hotkey,
+        m->QtWayland::vicinae_hotkey_manager_v1::bind(
+            keysym,
+            toNativeModifiers(key_combination.keyboardModifiers()),
+            nullptr,
+            QGuiApplication::applicationName(),
+            tr("Show/hide Albert")));
+
+    QEventLoop loop;
+    hotkey->d->on_settled = [&loop] { loop.quit(); };
+    QTimer::singleShot(bind_reply_timeout_ms, &loop, &QEventLoop::quit);
+    if (hotkey->d->state == Private::State::Pending)
+        loop.exec();
+    hotkey->d->on_settled = nullptr;
+
+    switch (hotkey->d->state)
+    {
+    case Private::State::Bound:
+        return hotkey;
+    case Private::State::Denied:
+        return unexpected(hotkey->d->denial_message);
+    default:
+        return unexpected(u"Compositor did not answer the bind request."_s);
+    }
+}

--- a/src/platform/xdg/waylandhotkey.h
+++ b/src/platform/xdg/waylandhotkey.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2026-2026 Aurelien Brabant
+
+#pragma once
+#include <QKeyCombination>
+#include <QObject>
+#include <expected>
+#include <memory>
+
+class WaylandHotkey : public QObject
+{
+    Q_OBJECT
+
+public:
+    ~WaylandHotkey();
+
+    static bool isPlatformSupported();
+    static std::expected<std::unique_ptr<WaylandHotkey>, QString> grab(QKeyCombination);
+
+private:
+    WaylandHotkey();
+
+    class Private;
+    std::unique_ptr<Private> d;
+
+signals:
+    void activated();
+    void revoked(const QString &message);
+};


### PR DESCRIPTION
Hi there!

This PR implements the [vicinae-hotkey-v1](https://github.com/vicinaehq/vicinae-wayland-protocols/tree/main/staging/vicinae-hotkey) in order to provide a working global shortcut backend on Wayland. 

This protocol was designed to fit existing approaches so it's a pretty good match for the existing abstraction.

The protocol is currently implemented by [Hyprland](https://github.com/hyprwm/Hyprland/pull/15010) and a few other clients such as [ghostty](https://github.com/ghostty-org/ghostty/pull/13464) and of course [vicinae](https://github.com/vicinaehq/vicinae) which is where it originally came from.

For what it's worth, there is an official [wayland-protocols](https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/525) proposal as well.

There is also [this video](https://www.youtube.com/watch?v=VEXugiJsNbM) discussing it.

The goal is to spread this protocol as much as possible and iterate on it as we go, so if you are okay to merge this feel free to assign me any related issue the users of Albert may have using it.

Just a note about the implementation although it is quite straightforward: unlike the QHotkey interface the bind is delivered asynchronously, so in my implementation I run a nested event loop for a brief moment in order to wait for the response. In practice, this takes a few milliseconds so not noticeable.